### PR TITLE
docs(ci): PR-event evidence probe

### DIFF
--- a/CI_PR_EVENT_EVIDENCE.md
+++ b/CI_PR_EVENT_EVIDENCE.md
@@ -1,0 +1,5 @@
+# CI PR-event Evidence Probe
+
+This branch exists to trigger the GitHub Actions workflow `CI - PR Checks` on `pull_request` and capture timing/flake evidence.
+
+Safe to close without merging.


### PR DESCRIPTION
This PR exists only to trigger the GitHub Actions workflow `CI - PR Checks` on `pull_request` and capture timing/flake evidence.

Safe to close without merging.