### PR TITLE
fix(i18n): add common namespace prefix for a11y translations

### DIFF
--- a/src/stackflow/activities/tabs/HomeTab.tsx
+++ b/src/stackflow/activities/tabs/HomeTab.tsx
@@ -110,7 +110,7 @@ export function HomeTab() {
           data-testid="chain-selector"
           onClick={() => setChainSheetOpen(true)}
           className="mb-4 flex items-center gap-2 rounded-full bg-white/20 px-3 py-1.5 text-sm text-white"
-          aria-label={t("a11y.chainSelector")}
+          aria-label={t("common:a11y.chainSelector")}
         >
           <ChainIcon chain={selectedChain} size="sm" />
           <span>{selectedChainName}</span>
@@ -186,7 +186,7 @@ export function HomeTab() {
       <button
         onClick={() => push("ScannerActivity", {})}
         className="fixed right-6 bottom-[calc(env(safe-area-inset-bottom)+5rem)] z-60 flex size-14 items-center justify-center rounded-full bg-primary shadow-lg transition-transform hover:scale-105 active:scale-95"
-        aria-label={t("a11y.scan")}
+        aria-label={t("common:a11y.scan")}
       >
         <IconLineScan className="size-6 text-primary-foreground" />
       </button>

--- a/src/stackflow/activities/tabs/TransferTab.tsx
+++ b/src/stackflow/activities/tabs/TransferTab.tsx
@@ -11,7 +11,7 @@ export function TransferTab() {
 
   return (
     <div className="flex min-h-screen flex-col bg-muted/30">
-      <PageHeader title={t("a11y.tabTransfer")} />
+      <PageHeader title={t("common:a11y.tabTransfer")} />
 
       <div className="flex flex-col gap-4 p-4">
       <Card>


### PR DESCRIPTION
修复 Transfer 和 Home Tab 页面的 i18n 翻译问题。

## 问题
当使用 `useTranslation(['transaction', 'common'])` 时，第一个命名空间成为默认命名空间，导致 `t('a11y.xxx')` 在 `transaction` 中查找而非 `common`，显示原始键名而非翻译文本。

## 修复
- `TransferTab.tsx`: `t("a11y.tabTransfer")` → `t("common:a11y.tabTransfer")`
- `HomeTab.tsx`: 
  - `t("a11y.chainSelector")` → `t("common:a11y.chainSelector")`
  - `t("a11y.scan")` → `t("common:a11y.scan")`

## 测试
- [x] 1307 单元测试通过
- [x] i18n 验证脚本通过
- [x] TypeScript 类型检查通过