### PR TITLE
fix(i18n): rename duplicate 'transfer' key in transaction.json

### DIFF
--- a/src/i18n/locales/ar/transaction.json
+++ b/src/i18n/locales/ar/transaction.json
@@ -201,7 +201,7 @@
   "transactionHash": "Transaction Hash",
   "transactionHistory": "Transaction history",
   "transactionSentSuccessfully": "Transaction sent successfully",
-  "transfer": "Transfer",
+  "transferAction": "Transfer",
   "transferAmount": "Transfer amount",
   "transferQuantityCannotBeGreaterThanBalance": "Transfer quantity cannot be greater than balance",
   "transferring": "Transferring",

--- a/src/i18n/locales/en/transaction.json
+++ b/src/i18n/locales/en/transaction.json
@@ -201,7 +201,7 @@
   "transactionHash": "Transaction Hash",
   "transactionHistory": "Transaction history",
   "transactionSentSuccessfully": "Transaction sent successfully",
-  "transfer": "Transfer",
+  "transferAction": "Transfer",
   "transferAmount": "Transfer amount",
   "transferQuantityCannotBeGreaterThanBalance": "Transfer quantity cannot be greater than balance",
   "transferring": "Transferring",

--- a/src/i18n/locales/zh-CN/transaction.json
+++ b/src/i18n/locales/zh-CN/transaction.json
@@ -205,7 +205,7 @@
   "transactionHash": "交易哈希",
   "transactionHistory": "交易历史",
   "transactionSentSuccessfully": "交易已发送",
-  "transfer": "转账",
+  "transferAction": "转账",
   "transferAmount": "转账金额",
   "transferQuantityCannotBeGreaterThanBalance": "转移数量不能大于余额",
   "transferring": "转移中",

--- a/src/i18n/locales/zh-TW/transaction.json
+++ b/src/i18n/locales/zh-TW/transaction.json
@@ -197,7 +197,7 @@
   "transactionHash": "交易哈希",
   "transactionHistory": "交易歷史",
   "transactionSentSuccessfully": "交易已發送",
-  "transfer": "轉賬",
+  "transferAction": "轉賬",
   "transferAmount": "轉帳金額",
   "transferQuantityCannotBeGreaterThanBalance": "轉移數量不能大於餘額",
   "transferring": "轉移中",


### PR DESCRIPTION
## 问题
Transfer 页面的翻译显示原始键名（如 `transfer.quickTransfer`）而非翻译文本。

## 根本原因
transaction.json 文件中存在重复的 `transfer` 键：
- 第 2 行：`"transfer": { ... }` 对象（包含 TransferTab 所需的所有嵌套翻译）
- 第 200+ 行：`"transfer": "轉賬"` 字符串

在 JSON 中，后面的键会覆盖前面的，所以字符串覆盖了整个对象，导致所有 `transfer.*` 翻译失效。

## 修复
将字符串键从 `"transfer"` 重命名为 `"transferAction"`，避免与对象键冲突。

## 影响的文件
- src/i18n/locales/en/transaction.json
- src/i18n/locales/zh-CN/transaction.json
- src/i18n/locales/zh-TW/transaction.json
- src/i18n/locales/ar/transaction.json

## 测试
- [x] TypeScript 类型检查通过