### PR TITLE
fix(wallet): restore import and wallet actions

### DIFF
--- a/src/components/wallet/wallet-edit-sheet.test.tsx
+++ b/src/components/wallet/wallet-edit-sheet.test.tsx
@@ -125,7 +125,7 @@ describe('WalletEditSheet', () => {
     fireEvent.click(screen.getByRole('button', { name: '保存' }))
 
     expect(updateWalletNameSpy).toHaveBeenCalledWith('1', 'New Name')
-    expect(mockOnSuccess).toHaveBeenCalled()
+    expect(mockOnSuccess).toHaveBeenCalledWith('rename')
     expect(mockOnClose).toHaveBeenCalled()
   })
 
@@ -211,7 +211,7 @@ describe('WalletEditSheet', () => {
       expect(deleteWalletSpy).toHaveBeenCalledWith('1')
     })
 
-    expect(mockOnSuccess).toHaveBeenCalled()
+    expect(mockOnSuccess).toHaveBeenCalledWith('delete')
   })
 
   it('shows error on wrong password', async () => {

--- a/src/lib/crypto/mnemonic.ts
+++ b/src/lib/crypto/mnemonic.ts
@@ -16,7 +16,7 @@ export function generateMnemonic(strength: MnemonicStrength = 128): string[] {
  */
 export function validateMnemonic(words: string[]): boolean {
   const mnemonic = words.join(' ').toLowerCase().trim()
-  return bip39.validateMnemonic(mnemonic)
+  return getAllWordLists().some((list) => bip39.validateMnemonic(mnemonic, list))
 }
 
 /**
@@ -42,7 +42,8 @@ export function getWordList(): string[] {
  * 检查单词是否在 BIP39 单词表中
  */
 export function isValidWord(word: string): boolean {
-  return bip39.wordlists.english!.includes(word.toLowerCase())
+  const normalized = word.toLowerCase()
+  return getAllWordLists().some((list) => list.includes(normalized))
 }
 
 /**
@@ -54,4 +55,10 @@ export function searchWords(prefix: string, limit = 5): string[] {
   return bip39.wordlists.english!
     .filter((word) => word.startsWith(lowerPrefix))
     .slice(0, limit)
+}
+
+function getAllWordLists(): string[][] {
+  return Object.values(bip39.wordlists).filter(
+    (list): list is string[] => Array.isArray(list),
+  )
 }


### PR DESCRIPTION
## Summary
- allow mnemonic validation across all BIP39 wordlists
- wire wallet detail actions: rename/delete via WalletEditSheet and export mnemonic navigation
- add support for initial delete/rename modes in WalletEditSheet
- update WalletEditSheet tests

## Testing
- not run