### PR TITLE
feat: migrate transaction history to TanStack Query

### DIFF
--- a/src/pages/history/index.test.tsx
+++ b/src/pages/history/index.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { TransactionHistoryPage } from './index'
 import { TestI18nProvider } from '@/test/i18n-mock'
 
@@ -78,10 +79,11 @@ const mockTransactions = [
 ]
 
 const mockSetFilter = vi.fn()
-vi.mock('@/hooks/use-transaction-history', () => ({
-  useTransactionHistory: () => ({
+vi.mock('@/queries', () => ({
+  useTransactionHistoryQuery: () => ({
     transactions: mockTransactions,
     isLoading: false,
+    isFetching: false,
     error: undefined,
     filter: { chain: 'all', period: 'all' },
     setFilter: mockSetFilter,
@@ -90,7 +92,16 @@ vi.mock('@/hooks/use-transaction-history', () => ({
 }))
 
 function renderWithProviders(ui: React.ReactElement) {
-  return render(<TestI18nProvider>{ui}</TestI18nProvider>)
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TestI18nProvider>{ui}</TestI18nProvider>
+    </QueryClientProvider>
+  )
 }
 
 describe('TransactionHistoryPage', () => {

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { IconRefresh as RefreshCw, IconFilter as Filter } from '@tabler/icons-react';
 import { PageHeader } from '@/components/layout/page-header';
 import { TransactionList } from '@/components/transaction/transaction-list';
-import { useTransactionHistory, type TransactionFilter } from '@/hooks/use-transaction-history';
+import { useTransactionHistoryQuery, type TransactionFilter } from '@/queries';
 import { useCurrentWallet, useEnabledChains } from '@/stores';
 import { cn } from '@/lib/utils';
 import type { TransactionInfo } from '@/components/transaction/transaction-item';
@@ -23,7 +23,8 @@ export function TransactionHistoryPage() {
   const currentWallet = useCurrentWallet();
   const enabledChains = useEnabledChains();
   const { t } = useTranslation(['transaction', 'common']);
-  const { transactions, isLoading, filter, setFilter, refresh } = useTransactionHistory(currentWallet?.id);
+  // 使用 TanStack Query 管理交易历史
+  const { transactions, isLoading, isFetching, filter, setFilter, refresh } = useTransactionHistoryQuery(currentWallet?.id);
   const chainOptions: { value: ChainType | 'all'; labelKey?: string; label?: string }[] = [
     { value: 'all', labelKey: 'transaction:history.filter.allChains' },
     ...enabledChains.map((chain) => ({
@@ -76,11 +77,11 @@ export function TransactionHistoryPage() {
         rightAction={
           <button
             onClick={refresh}
-            disabled={isLoading}
+            disabled={isFetching}
             className={cn(
               'rounded-full p-2 transition-colors',
               'hover:bg-muted active:bg-muted/80',
-              isLoading && 'animate-spin',
+              isFetching && 'animate-spin',
             )}
             aria-label={t('common:a11y.refresh')}
           >

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -13,3 +13,11 @@ export {
   useRefreshBalance,
   balanceQueryKeys,
 } from './use-balance-query'
+
+export {
+  useTransactionHistoryQuery,
+  useRefreshTransactionHistory,
+  transactionHistoryKeys,
+  type TransactionFilter,
+  type TransactionRecord,
+} from './use-transaction-history-query'

--- a/src/queries/use-transaction-history-query.ts
+++ b/src/queries/use-transaction-history-query.ts
@@ -1,0 +1,124 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import type { ChainType } from '@/stores'
+import type { TransactionInfo } from '@/components/transaction/transaction-item'
+import {
+  transactionService,
+  type TransactionRecord as ServiceTransactionRecord,
+  type TransactionFilter as ServiceFilter,
+} from '@/services/transaction'
+
+/** 交易历史过滤器 */
+export interface TransactionFilter {
+  chain?: ChainType | 'all' | undefined
+  period?: '7d' | '30d' | '90d' | 'all' | undefined
+}
+
+/** 扩展的交易信息（包含链类型）- 保持与组件兼容 */
+export interface TransactionRecord extends TransactionInfo {
+  chain: ChainType
+  fee: string | undefined
+  feeSymbol: string | undefined
+  blockNumber: number | undefined
+  confirmations: number | undefined
+}
+
+/**
+ * Transaction History Query Keys
+ */
+export const transactionHistoryKeys = {
+  all: ['transactionHistory'] as const,
+  wallet: (walletId: string) => ['transactionHistory', walletId] as const,
+  filtered: (walletId: string, filter: TransactionFilter) =>
+    ['transactionHistory', walletId, filter] as const,
+}
+
+/** 将 Service 记录转换为组件兼容格式 */
+function convertToComponentFormat(record: ServiceTransactionRecord): TransactionRecord {
+  return {
+    id: record.id,
+    type: record.type,
+    status: record.status,
+    amount: record.amount,
+    symbol: record.symbol,
+    address: record.address,
+    timestamp: record.timestamp,
+    hash: record.hash,
+    chain: record.chain,
+    fee: record.fee,
+    feeSymbol: record.feeSymbol,
+    blockNumber: record.blockNumber,
+    confirmations: record.confirmations,
+  }
+}
+
+/**
+ * Transaction History Query Hook
+ *
+ * 特性：
+ * - 30s staleTime：Tab 切换不重复请求
+ * - 支持按链/时间筛选
+ * - 共享缓存：多个组件使用同一 key 时共享数据
+ * - 自动请求去重
+ */
+export function useTransactionHistoryQuery(walletId?: string) {
+  const [filter, setFilter] = useState<TransactionFilter>({ chain: 'all', period: 'all' })
+  const queryClient = useQueryClient()
+
+  const query = useQuery({
+    queryKey: transactionHistoryKeys.filtered(walletId ?? '', filter),
+    queryFn: async (): Promise<TransactionRecord[]> => {
+      if (!walletId) return []
+
+      const serviceFilter: ServiceFilter = {
+        chain: filter.chain ?? 'all',
+        period: filter.period ?? 'all',
+        type: undefined,
+        status: undefined,
+      }
+
+      const records = await transactionService.getHistory({ walletId, filter: serviceFilter })
+      return records.map(convertToComponentFormat)
+    },
+    enabled: !!walletId,
+    staleTime: 30 * 1000, // 30 秒内认为数据新鲜
+    gcTime: 5 * 60 * 1000, // 5 分钟缓存
+    refetchOnWindowFocus: true,
+  })
+
+  const refresh = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: transactionHistoryKeys.wallet(walletId ?? ''),
+    })
+  }
+
+  return {
+    transactions: query.data ?? [],
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.error?.message,
+    filter,
+    setFilter,
+    refresh,
+  }
+}
+
+/**
+ * 手动刷新交易历史
+ */
+export function useRefreshTransactionHistory() {
+  const queryClient = useQueryClient()
+
+  return {
+    refresh: async (walletId: string) => {
+      await queryClient.invalidateQueries({
+        queryKey: transactionHistoryKeys.wallet(walletId),
+      })
+    },
+    refreshAll: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: transactionHistoryKeys.all,
+      })
+    },
+  }
+}

--- a/src/stackflow/activities/tabs/TransferTab.tsx
+++ b/src/stackflow/activities/tabs/TransferTab.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { PageHeader } from "@/components/layout/page-header";
 import { TransactionItem } from "@/components/transaction/transaction-item";
-import { useTransactionHistory } from "@/hooks/use-transaction-history";
+import { useTransactionHistoryQuery } from "@/queries";
 import { addressBookActions, addressBookStore, useCurrentWallet, useSelectedChain } from "@/stores";
 import { IconSend } from "@tabler/icons-react";
 
@@ -17,7 +17,10 @@ export function TransferTab() {
   const selectedChain = useSelectedChain();
   const addressBookState = useStore(addressBookStore);
   const contacts = addressBookState.contacts;
-  const { transactions, isLoading } = useTransactionHistory(currentWallet?.id);
+  // 使用 TanStack Query 管理交易历史
+  // - 30s staleTime: Tab 切换不会重复请求
+  // - 共享缓存: 多个组件使用同一数据
+  const { transactions, isLoading } = useTransactionHistoryQuery(currentWallet?.id);
 
   useEffect(() => {
     if (!addressBookState.isInitialized) {


### PR DESCRIPTION
Closes #44

## 改动

- 创建 `useTransactionHistoryQuery` hook
  - 30s staleTime: Tab 切换不重复请求
  - 共享缓存
  - 请求去重
- 更新 TransferTab 使用新 hook
- 更新 TransactionHistoryPage 使用新 hook
- 更新测试添加 QueryClientProvider

## 效果

```
之前: Tab 切换 → useEffect 触发 → 每次都发起请求
现在: Tab 切换 → 检查缓存 → 30s 内用缓存
```