### PR TITLE
feat: add price and exchange rate query hooks

### DIFF
--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -21,3 +21,16 @@ export {
   type TransactionFilter,
   type TransactionRecord,
 } from './use-transaction-history-query'
+
+export {
+  usePriceQuery,
+  getPrice,
+  priceQueryKeys,
+  type PriceData,
+} from './use-price-query'
+
+export {
+  useExchangeRateQuery,
+  getExchangeRate,
+  exchangeRateQueryKeys,
+} from './use-exchange-rate-query'

--- a/src/queries/use-exchange-rate-query.ts
+++ b/src/queries/use-exchange-rate-query.ts
@@ -1,0 +1,78 @@
+import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import { currencyExchangeService, type ExchangeRateResponse } from '@/services'
+
+/**
+ * Exchange Rate Query Keys
+ */
+export const exchangeRateQueryKeys = {
+  all: ['exchangeRate'] as const,
+  rate: (baseCurrency: string, targetCurrencies: string[]) =>
+    ['exchangeRate', baseCurrency.toUpperCase(), targetCurrencies.sort().join(',')] as const,
+}
+
+function normalizeCurrencyCode(code: string): string {
+  return code.trim().toUpperCase()
+}
+
+/**
+ * Exchange Rate Query Hook
+ *
+ * 特性：
+ * - 5min staleTime：替代手动缓存
+ * - 共享缓存：多个组件使用同一 base+targets 时共享数据
+ * - 请求去重：同时发起的相同请求会被合并
+ */
+export function useExchangeRateQuery(
+  baseCurrency: string,
+  targetCurrencies: string[]
+) {
+  const normalizedBase = useMemo(() => normalizeCurrencyCode(baseCurrency), [baseCurrency])
+  const normalizedTargets = useMemo(
+    () => [...new Set(targetCurrencies.map(normalizeCurrencyCode))].filter((c) => c !== normalizedBase),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [targetCurrencies.join(','), normalizedBase]
+  )
+
+  const query = useQuery({
+    queryKey: exchangeRateQueryKeys.rate(normalizedBase, normalizedTargets),
+    queryFn: async (): Promise<ExchangeRateResponse> => {
+      if (normalizedTargets.length === 0) {
+        const datePart = new Date().toISOString().split('T')[0]
+        return {
+          base: normalizedBase,
+          date: datePart ?? new Date().toISOString().slice(0, 10),
+          rates: {},
+        }
+      }
+
+      return currencyExchangeService.getExchangeRates({
+        baseCurrency: normalizedBase,
+        targetCurrencies: normalizedTargets,
+      })
+    },
+    enabled: !!normalizedBase,
+    staleTime: 5 * 60 * 1000, // 5 分钟内认为数据新鲜
+    gcTime: 10 * 60 * 1000, // 10 分钟缓存
+    refetchOnWindowFocus: true,
+  })
+
+  return {
+    data: query.data ?? null,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.error?.message ?? null,
+    updatedAt: query.dataUpdatedAt || null,
+  }
+}
+
+/**
+ * Get exchange rate for a single currency
+ */
+export function getExchangeRate(
+  data: ExchangeRateResponse | null,
+  targetCurrency: string
+): number | undefined {
+  const normalizedTarget = normalizeCurrencyCode(targetCurrency)
+  return data?.rates[normalizedTarget]
+}

--- a/src/queries/use-price-query.ts
+++ b/src/queries/use-price-query.ts
@@ -1,0 +1,89 @@
+import { useQuery } from '@tanstack/react-query'
+
+/** Price data for a single token */
+export interface PriceData {
+  priceUsd: number
+  priceChange24h: number
+  updatedAt: number
+}
+
+/** Mock price data for development */
+const MOCK_PRICES: Record<string, PriceData> = {
+  ETH: { priceUsd: 2500, priceChange24h: 2.3, updatedAt: Date.now() },
+  BTC: { priceUsd: 45000, priceChange24h: -1.5, updatedAt: Date.now() },
+  USDT: { priceUsd: 1, priceChange24h: 0.01, updatedAt: Date.now() },
+  USDC: { priceUsd: 1, priceChange24h: -0.02, updatedAt: Date.now() },
+  BFM: { priceUsd: 0.05, priceChange24h: 5.2, updatedAt: Date.now() },
+  TRX: { priceUsd: 0.12, priceChange24h: 3.1, updatedAt: Date.now() },
+  BNB: { priceUsd: 320, priceChange24h: 1.8, updatedAt: Date.now() },
+}
+
+/**
+ * Price Query Keys
+ */
+export const priceQueryKeys = {
+  all: ['prices'] as const,
+  symbols: (symbols: string[]) => ['prices', symbols.sort().join(',')] as const,
+}
+
+/**
+ * Fetch prices for given symbols
+ */
+async function fetchPrices(symbols: string[]): Promise<Map<string, PriceData>> {
+  const now = Date.now()
+
+  // TODO: Replace with actual API call (CoinGecko, etc.)
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  const prices = new Map<string, PriceData>()
+  for (const symbol of symbols) {
+    const upperSymbol = symbol.toUpperCase()
+    const mockPrice = MOCK_PRICES[upperSymbol]
+    if (mockPrice) {
+      prices.set(upperSymbol, { ...mockPrice, updatedAt: now })
+    }
+  }
+
+  return prices
+}
+
+/**
+ * Price Query Hook
+ *
+ * 特性：
+ * - 5min staleTime：替代手动缓存
+ * - 60s 轮询：自动刷新价格
+ * - 共享缓存：多个组件使用同一 symbols 时共享数据
+ * - 请求去重：同时发起的相同请求会被合并
+ */
+export function usePriceQuery(symbols: string[]) {
+  const normalizedSymbols = symbols.map((s) => s.toUpperCase()).filter(Boolean)
+
+  const query = useQuery({
+    queryKey: priceQueryKeys.symbols(normalizedSymbols),
+    queryFn: () => fetchPrices(normalizedSymbols),
+    enabled: normalizedSymbols.length > 0,
+    staleTime: 5 * 60 * 1000, // 5 分钟内认为数据新鲜
+    gcTime: 10 * 60 * 1000, // 10 分钟缓存
+    refetchInterval: 60 * 1000, // 60 秒轮询
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
+  })
+
+  return {
+    prices: query.data ?? new Map<string, PriceData>(),
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.error?.message ?? null,
+  }
+}
+
+/**
+ * Get price for a single token from the prices map
+ */
+export function getPrice(
+  prices: Map<string, PriceData>,
+  symbol: string
+): PriceData | undefined {
+  return prices.get(symbol.toUpperCase())
+}


### PR DESCRIPTION
Closes #45
Closes #46

## 改动

添加两个 TanStack Query hooks：

### usePriceQuery (#45)
- 5min staleTime：替代手动 5min 缓存
- 60s 轮询：自动刷新价格
- 共享缓存和请求去重

### useExchangeRateQuery (#46)  
- 5min staleTime：替代手动 5min 缓存
- 共享缓存和请求去重

保留原有 hooks 以保持向后兼容。