### PR TITLE
fix(cd): add GNU tar setup for self-hosted macOS runner

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,6 +42,14 @@ jobs:
       channel: ${{ steps.channel.outputs.channel }}
 
     steps:
+      - name: Setup GNU tar (required for actions/upload-pages-artifact)
+        run: |
+          # macOS uses BSD tar by default, but upload-pages-artifact requires GNU tar (gtar)
+          if ! command -v gtar &> /dev/null; then
+            brew install gnu-tar
+          fi
+          echo "$(brew --prefix gnu-tar)/libexec/gnubin" >> $GITHUB_PATH
+
       - name: Git checkout
         run: |
           if [ ! -d ".git" ]; then


### PR DESCRIPTION
## Problem
The `actions/upload-pages-artifact` action requires GNU tar (`gtar`), but macOS uses BSD tar by default. This causes the CD to fail on self-hosted macOS runners.

## Solution
Add a step to install `gnu-tar` via Homebrew if not already installed, and add it to the PATH.

## Error fixed
```
/Users/kzf/Development/actions-runner/_work/_temp/xxx.sh: line 3: gtar: command not found
```