### PR TITLE
ci: separate fast/standard into independent paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,3 +122,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "CI standard passed"
+
+  # ==================== 聚合 Job（满足分支保护） ====================
+  checks:
+    if: always()
+    needs: [checks-fast, checks-standard]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          if [ "${{ needs.checks-fast.result }}" == "success" ] || [ "${{ needs.checks-standard.result }}" == "success" ]; then
+            echo "CI passed via $( [ '${{ needs.checks-fast.result }}' == 'success' ] && echo 'fast path' || echo 'standard path' )"
+            exit 0
+          fi
+          echo "CI failed: fast=${{ needs.checks-fast.result }}, standard=${{ needs.checks-standard.result }}"
+          exit 1


### PR DESCRIPTION
Two independent CI paths:

- **Self-hosted**: `ci-fast` → `checks-fast`
- **GitHub-hosted**: `ci-standard` → `checks-standard`

Branch protection should set both `checks-fast` and `checks-standard` as required. Skipped jobs won't block merge.