### PR TITLE
feat(transfer): add pay password support for BioForest Chain

### DIFF
--- a/e2e/bioforest-transfer.spec.ts
+++ b/e2e/bioforest-transfer.spec.ts
@@ -1,0 +1,225 @@
+import { test, expect, type Page } from '@playwright/test'
+import { setupWalletWithMnemonic, waitForAppReady } from './utils/indexeddb-helper'
+
+/**
+ * BioForest Chain 转账完整测试
+ *
+ * 测试内容：
+ * - 交易历史查询
+ * - 手续费计算
+ * - 支付密码（二次签名）设置
+ * - 转账功能
+ */
+
+// 测试账号助记词
+const TEST_MNEMONIC = '董 夜 孟 和 罚 箱 房 五 汁 搬 渗 县 督 细 速 连 岭 爸 养 谱 握 杭 刀 拆'
+const TEST_ADDRESS = 'b9gB9NzHKWsDKGYFCaNva6xRnxPwFfGcfx'
+const TARGET_ADDRESS = 'bCfAynSAKhzgKLi3BXyuh5k22GctLR72j'
+
+// 测试 API 配置
+const RPC_URL = 'https://walletapi.bffmeta.info'
+const CHAIN_ID = 'bfm'
+
+test.describe('BioForest Chain API 功能测试', () => {
+  test('获取最新区块高度', async ({ request }) => {
+    const response = await request.get(`${RPC_URL}/wallet/${CHAIN_ID}/lastblock`)
+    expect(response.ok()).toBe(true)
+    
+    const data = await response.json()
+    expect(data).toHaveProperty('height')
+    expect(data).toHaveProperty('timestamp')
+    expect(typeof data.height).toBe('number')
+    expect(data.height).toBeGreaterThan(0)
+    
+    console.log(`Latest block: height=${data.height}, timestamp=${data.timestamp}`)
+  })
+
+  test('查询账户余额', async ({ request }) => {
+    const response = await request.post(`${RPC_URL}/wallet/${CHAIN_ID}/address/balance`, {
+      data: {
+        address: TEST_ADDRESS,
+        magic: 'nxOGQ',
+        assetType: 'BFM',
+      },
+    })
+    expect(response.ok()).toBe(true)
+    
+    const data = await response.json()
+    expect(data).toHaveProperty('amount')
+    
+    console.log(`Balance for ${TEST_ADDRESS}: ${data.amount}`)
+  })
+
+  test('查询账户信息（包含二次签名公钥）', async ({ request }) => {
+    const response = await request.post(`${RPC_URL}/wallet/${CHAIN_ID}/address/info`, {
+      data: {
+        address: TEST_ADDRESS,
+      },
+    })
+    expect(response.ok()).toBe(true)
+    
+    const data = await response.json()
+    console.log(`Address info for ${TEST_ADDRESS}:`, JSON.stringify(data, null, 2))
+    
+    // 检查是否有二次签名公钥
+    if (data?.secondPublicKey) {
+      console.log('Account has pay password set')
+    } else {
+      console.log('Account does NOT have pay password set')
+    }
+  })
+
+  test('查询交易历史', async ({ request }) => {
+    // 首先获取最新区块高度
+    const blockResponse = await request.get(`${RPC_URL}/wallet/${CHAIN_ID}/lastblock`)
+    const blockData = await blockResponse.json()
+    const maxHeight = blockData.height
+
+    // 查询交易
+    const response = await request.post(`${RPC_URL}/wallet/${CHAIN_ID}/transactions/query`, {
+      data: {
+        maxHeight,
+        address: TEST_ADDRESS,
+        page: 1,
+        pageSize: 10,
+        sort: -1,
+      },
+    })
+    expect(response.ok()).toBe(true)
+    
+    const data = await response.json()
+    console.log(`Transaction history for ${TEST_ADDRESS}:`)
+    console.log(`Total transactions found: ${data.trs?.length ?? 0}`)
+    
+    if (data.trs && data.trs.length > 0) {
+      // 打印前 3 条交易
+      data.trs.slice(0, 3).forEach((item: { transaction: { signature: string; type: string; senderId: string; recipientId: string; fee: string; timestamp: number } }, i: number) => {
+        const tx = item.transaction
+        console.log(`  [${i + 1}] Type: ${tx.type}`)
+        console.log(`      From: ${tx.senderId}`)
+        console.log(`      To: ${tx.recipientId}`)
+        console.log(`      Fee: ${tx.fee}`)
+        console.log(`      TxId: ${tx.signature.slice(0, 20)}...`)
+      })
+    }
+  })
+
+  test('查询 Pending 交易', async ({ request }) => {
+    const response = await request.post(`${RPC_URL}/wallet/${CHAIN_ID}/pendingTr`, {
+      data: {
+        senderId: TEST_ADDRESS,
+        sort: -1,
+      },
+    })
+    expect(response.ok()).toBe(true)
+    
+    const data = await response.json()
+    console.log(`Pending transactions: ${Array.isArray(data) ? data.length : 0}`)
+  })
+})
+
+test.describe('BioForest 钱包 UI 测试', () => {
+  test.beforeEach(async ({ page }) => {
+    // 设置测试钱包
+    await setupWalletWithMnemonic(page, TEST_MNEMONIC, 'test-password')
+  })
+
+  test('显示 BFM 余额', async ({ page }) => {
+    await page.goto('/')
+    await waitForAppReady(page)
+
+    // 截图初始状态
+    await page.waitForTimeout(1000)
+    await expect(page).toHaveScreenshot('bioforest-home.png')
+
+    // 验证页面显示
+    const content = await page.content()
+    expect(content).toContain('BFM')
+  })
+
+  test('发送页面加载正常', async ({ page }) => {
+    await page.goto('/#/send')
+    await waitForAppReady(page)
+
+    await page.waitForTimeout(500)
+    
+    // 截图发送页面
+    await expect(page).toHaveScreenshot('bioforest-send-page.png')
+  })
+
+  test('交易历史页面显示', async ({ page }) => {
+    await page.goto('/#/history')
+    await waitForAppReady(page)
+
+    await page.waitForTimeout(500)
+    
+    // 截图交易历史
+    await expect(page).toHaveScreenshot('bioforest-history.png')
+  })
+})
+
+test.describe('BioForest 转账流程测试', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupWalletWithMnemonic(page, TEST_MNEMONIC, 'test-password')
+  })
+
+  test('填写转账表单', async ({ page }) => {
+    await page.goto('/#/send')
+    await waitForAppReady(page)
+
+    // 填写收款地址
+    const addressInput = page.locator('input').first()
+    await addressInput.fill(TARGET_ADDRESS)
+
+    // 填写金额
+    const amountInput = page.locator('input').nth(1)
+    await amountInput.fill('0.0001')
+
+    await page.waitForTimeout(500)
+
+    // 截图填写后的状态
+    await expect(page).toHaveScreenshot('bioforest-send-filled.png')
+  })
+
+  test('确认转账弹窗', async ({ page }) => {
+    await page.goto('/#/send')
+    await waitForAppReady(page)
+
+    // 填写表单
+    const addressInput = page.locator('input').first()
+    await addressInput.fill(TARGET_ADDRESS)
+
+    const amountInput = page.locator('input').nth(1)
+    await amountInput.fill('0.0001')
+
+    // 等待费用计算
+    await page.waitForTimeout(1000)
+
+    // 点击继续
+    const continueBtn = page.locator('[data-testid="send-continue-button"]')
+    if (await continueBtn.isEnabled()) {
+      await continueBtn.click()
+      await page.waitForTimeout(500)
+
+      // 截图确认弹窗
+      await expect(page).toHaveScreenshot('bioforest-send-confirm.png')
+    }
+  })
+})
+
+test.describe('BioForest 支付密码设置', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupWalletWithMnemonic(page, TEST_MNEMONIC, 'test-password')
+  })
+
+  test('安全设置页面', async ({ page }) => {
+    // 导航到安全设置
+    await page.goto('/#/settings/security')
+    await waitForAppReady(page)
+
+    await page.waitForTimeout(500)
+
+    // 截图安全设置页面
+    await expect(page).toHaveScreenshot('bioforest-security-settings.png')
+  })
+})

--- a/scripts/test-bioforest-api.ts
+++ b/scripts/test-bioforest-api.ts
@@ -1,0 +1,146 @@
+#!/usr/bin/env tsx
+/**
+ * BioForest Chain API 测试脚本
+ *
+ * 用于验证真实网络功能:
+ * - 获取区块高度
+ * - 查询账户余额
+ * - 查询账户信息（二次签名公钥）
+ * - 查询交易历史
+ * - 计算手续费
+ */
+
+const RPC_URL = 'https://walletapi.bffmeta.info'
+const CHAIN_ID = 'bfm'
+const TEST_ADDRESS = 'b9gB9NzHKWsDKGYFCaNva6xRnxPwFfGcfx'
+
+async function testGetLastBlock() {
+  console.log('\n=== 测试获取最新区块 ===')
+  const response = await fetch(`${RPC_URL}/wallet/${CHAIN_ID}/lastblock`)
+  if (!response.ok) {
+    throw new Error(`Failed: ${response.status}`)
+  }
+  const data = await response.json()
+  console.log('最新区块高度:', data.height)
+  console.log('时间戳:', data.timestamp)
+  return data
+}
+
+async function testGetBalance() {
+  console.log('\n=== 测试查询余额 ===')
+  const response = await fetch(`${RPC_URL}/wallet/${CHAIN_ID}/address/balance`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      address: TEST_ADDRESS,
+      magic: 'nxOGQ',
+      assetType: 'BFM',
+    }),
+  })
+  if (!response.ok) {
+    throw new Error(`Failed: ${response.status}`)
+  }
+  const data = await response.json()
+  console.log(`地址 ${TEST_ADDRESS} 余额:`, data.amount)
+  console.log('格式化余额:', (parseFloat(data.amount) / 1e8).toFixed(8), 'BFM')
+  return data
+}
+
+async function testGetAddressInfo() {
+  console.log('\n=== 测试查询地址信息 ===')
+  const response = await fetch(`${RPC_URL}/wallet/${CHAIN_ID}/address/info`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ address: TEST_ADDRESS }),
+  })
+  if (!response.ok) {
+    console.log('查询失败或地址不存在')
+    return null
+  }
+  const data = await response.json()
+  console.log('地址信息:', JSON.stringify(data, null, 2))
+  if (data?.secondPublicKey) {
+    console.log('✅ 该账户已设置支付密码（二次签名）')
+  } else {
+    console.log('❌ 该账户未设置支付密码')
+  }
+  return data
+}
+
+async function testGetTransactionHistory(maxHeight: number) {
+  console.log('\n=== 测试查询交易历史 ===')
+  const response = await fetch(`${RPC_URL}/wallet/${CHAIN_ID}/transactions/query`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      maxHeight,
+      address: TEST_ADDRESS,
+      page: 1,
+      pageSize: 5,
+      sort: -1,
+    }),
+  })
+  if (!response.ok) {
+    throw new Error(`Failed: ${response.status}`)
+  }
+  const data = await response.json()
+  console.log(`找到 ${data.trs?.length ?? 0} 条交易记录`)
+  
+  if (data.trs && data.trs.length > 0) {
+    console.log('\n最近的交易:')
+    data.trs.slice(0, 3).forEach((item: unknown, i: number) => {
+      const tx = (item as { transaction: { signature: string; type: string; senderId: string; recipientId: string; fee: string; timestamp: number } }).transaction
+      console.log(`\n  [${i + 1}]`)
+      console.log(`    类型: ${tx.type}`)
+      console.log(`    发送方: ${tx.senderId}`)
+      console.log(`    接收方: ${tx.recipientId || '无'}`)
+      console.log(`    手续费: ${(parseFloat(tx.fee) / 1e8).toFixed(8)} BFM`)
+      console.log(`    交易ID: ${tx.signature.slice(0, 32)}...`)
+    })
+  }
+  return data
+}
+
+async function testGetPendingTransactions() {
+  console.log('\n=== 测试查询待处理交易 ===')
+  const response = await fetch(`${RPC_URL}/wallet/${CHAIN_ID}/pendingTr`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      senderId: TEST_ADDRESS,
+      sort: -1,
+    }),
+  })
+  if (!response.ok) {
+    throw new Error(`Failed: ${response.status}`)
+  }
+  const data = await response.json()
+  console.log(`待处理交易数: ${Array.isArray(data) ? data.length : 0}`)
+  return data
+}
+
+async function main() {
+  console.log('========================================')
+  console.log('BioForest Chain API 测试')
+  console.log('========================================')
+  console.log('RPC URL:', RPC_URL)
+  console.log('Chain ID:', CHAIN_ID)
+  console.log('测试地址:', TEST_ADDRESS)
+  
+  try {
+    const lastBlock = await testGetLastBlock()
+    await testGetBalance()
+    await testGetAddressInfo()
+    await testGetTransactionHistory(lastBlock.height)
+    await testGetPendingTransactions()
+    
+    console.log('\n========================================')
+    console.log('✅ 所有 API 测试通过!')
+    console.log('========================================')
+  } catch (error) {
+    console.error('\n❌ 测试失败:', error)
+    process.exit(1)
+  }
+}
+
+main()

--- a/src/hooks/use-send.bioforest.ts
+++ b/src/hooks/use-send.bioforest.ts
@@ -8,6 +8,8 @@ import {
   broadcastTransaction,
   getAddressInfo,
   verifyPayPassword,
+  setPayPassword,
+  getSignatureTransactionMinFee,
 } from '@/services/bioforest-sdk'
 
 export interface BioforestFeeResult {
@@ -184,5 +186,125 @@ export async function submitBioforestTransfer({
       status: 'error',
       message: errorMessage || '交易失败，请稍后重试',
     }
+  }
+}
+
+export type SetPayPasswordResult =
+  | { status: 'ok'; txHash: string }
+  | { status: 'password' }
+  | { status: 'already_set' }
+  | { status: 'error'; message: string }
+
+export interface SetPayPasswordParams {
+  chainConfig: ChainConfig
+  walletId: string
+  password: string
+  fromAddress: string
+  newPayPassword: string
+}
+
+/**
+ * Set pay password (二次签名) for an account
+ */
+export async function submitSetPayPassword({
+  chainConfig,
+  walletId,
+  password,
+  fromAddress,
+  newPayPassword,
+}: SetPayPasswordParams): Promise<SetPayPasswordResult> {
+  // Get mnemonic from wallet storage
+  let secret: string
+  try {
+    secret = await walletStorageService.getMnemonic(walletId, password)
+  } catch (error) {
+    if (error instanceof WalletStorageError && error.code === WalletStorageErrorCode.DECRYPTION_FAILED) {
+      return { status: 'password' }
+    }
+    return {
+      status: 'error',
+      message: error instanceof Error ? error.message : '未知错误',
+    }
+  }
+
+  const rpcUrl = chainConfig.rpcUrl
+  if (!rpcUrl) {
+    return { status: 'error', message: 'RPC URL 未配置' }
+  }
+
+  try {
+    // Check if already has pay password
+    const addressInfo = await getAddressInfo(rpcUrl, chainConfig.id, fromAddress)
+    if (addressInfo.secondPublicKey) {
+      return { status: 'already_set' }
+    }
+
+    // Set pay password
+    console.log('[submitSetPayPassword] Creating signature transaction...')
+    const result = await setPayPassword({
+      rpcUrl,
+      chainId: chainConfig.id,
+      mainSecret: secret,
+      newPaySecret: newPayPassword,
+    })
+
+    console.log('[submitSetPayPassword] Pay password set successfully:', result.txHash)
+    return { status: 'ok', txHash: result.txHash }
+  } catch (error) {
+    console.error('[submitSetPayPassword] Failed to set pay password:', error)
+
+    const errorMessage = error instanceof Error ? error.message : String(error)
+
+    if (errorMessage.includes('fee') || errorMessage.includes('手续费')) {
+      return { status: 'error', message: '余额不足以支付手续费' }
+    }
+
+    return {
+      status: 'error',
+      message: errorMessage || '设置支付密码失败，请稍后重试',
+    }
+  }
+}
+
+/**
+ * Get the minimum fee for setting pay password
+ */
+export async function getSetPayPasswordFee(
+  chainConfig: ChainConfig,
+): Promise<{ amount: Amount; symbol: string } | null> {
+  const rpcUrl = chainConfig.rpcUrl
+  if (!rpcUrl) {
+    return null
+  }
+
+  try {
+    const feeRaw = await getSignatureTransactionMinFee(rpcUrl, chainConfig.id)
+    return {
+      amount: Amount.fromRaw(feeRaw, chainConfig.decimals, chainConfig.symbol),
+      symbol: chainConfig.symbol,
+    }
+  } catch (error) {
+    console.error('[getSetPayPasswordFee] Failed to get fee:', error)
+    return null
+  }
+}
+
+/**
+ * Check if address has pay password set
+ */
+export async function hasPayPasswordSet(
+  chainConfig: ChainConfig,
+  address: string,
+): Promise<boolean> {
+  const rpcUrl = chainConfig.rpcUrl
+  if (!rpcUrl) {
+    return false
+  }
+
+  try {
+    const info = await getAddressInfo(rpcUrl, chainConfig.id, address)
+    return !!info.secondPublicKey
+  } catch {
+    return false
   }
 }

--- a/src/i18n/locales/en/security.json
+++ b/src/i18n/locales/en/security.json
@@ -27,6 +27,24 @@
     "biometric": "Use Biometrics",
     "cancel": "Cancel"
   },
+  "payPassword": {
+    "setTitle": "Set Pay Password",
+    "tooShort": "Pay password must be at least 6 characters",
+    "notMatch": "Passwords do not match",
+    "setFailed": "Failed to set pay password, please try again",
+    "setSuccess": "Pay Password Set Successfully",
+    "setSuccessDesc": "You will need to enter your pay password for each transfer",
+    "feeInfo": "Setting pay password requires a network fee",
+    "inputDesc": "Set a pay password to protect your transfers",
+    "inputPlaceholder": "Enter pay password",
+    "confirmDesc": "Enter pay password again to confirm",
+    "confirmPlaceholder": "Confirm pay password",
+    "walletPasswordDesc": "Enter wallet password to confirm",
+    "walletPasswordPlaceholder": "Enter wallet password",
+    "alreadySet": "Pay password is already set for this address",
+    "notSet": "Pay password not set",
+    "setPayPassword": "Set Pay Password"
+  },
   "mnemonicConfirm": {
     "selected": "Selected {{current}}/{{total}}",
     "undo": "Undo",

--- a/src/i18n/locales/zh-CN/security.json
+++ b/src/i18n/locales/zh-CN/security.json
@@ -27,6 +27,24 @@
     "biometric": "使用生物识别",
     "cancel": "取消"
   },
+  "payPassword": {
+    "setTitle": "设置支付密码",
+    "tooShort": "支付密码至少6个字符",
+    "notMatch": "两次输入的密码不一致",
+    "setFailed": "设置支付密码失败，请稍后重试",
+    "setSuccess": "支付密码设置成功",
+    "setSuccessDesc": "之后每次转账都需要输入支付密码进行验证",
+    "feeInfo": "设置支付密码需要支付网络手续费",
+    "inputDesc": "请设置一个支付密码，用于保护您的转账安全",
+    "inputPlaceholder": "请输入支付密码",
+    "confirmDesc": "请再次输入支付密码以确认",
+    "confirmPlaceholder": "请再次输入支付密码",
+    "walletPasswordDesc": "请输入钱包密码以确认设置",
+    "walletPasswordPlaceholder": "请输入钱包密码",
+    "alreadySet": "该地址已设置支付密码",
+    "notSet": "未设置支付密码",
+    "setPayPassword": "设置支付密码"
+  },
   "mnemonicConfirm": {
     "selected": "已选择 {{current}}/{{total}}",
     "undo": "撤销",

--- a/src/stackflow/activities/sheets/SetPayPasswordJob.tsx
+++ b/src/stackflow/activities/sheets/SetPayPasswordJob.tsx
@@ -1,0 +1,300 @@
+import { useState, useCallback, useEffect } from "react";
+import type { ActivityComponentType } from "@stackflow/react";
+import { BottomSheet } from "@/components/layout/bottom-sheet";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import { PasswordInput } from "@/components/security/password-input";
+import {
+  IconAlertCircle as AlertCircle,
+  IconLock as Lock,
+  IconCheck as Check,
+  IconInfoCircle as InfoCircle,
+} from "@tabler/icons-react";
+import { useFlow } from "../../stackflow";
+import { ActivityParamsProvider, useActivityParams } from "../../hooks";
+import { Amount } from "@/types/amount";
+
+// Global callback store for setting pay password
+let pendingCallback: ((newPayPassword: string, walletPassword: string) => Promise<{ success: boolean; txHash?: string; error?: string }>) | null = null;
+let feeAmount: Amount | null = null;
+let feeSymbol: string = "";
+
+/**
+ * Set the callback for setting pay password before pushing this activity
+ */
+export function setSetPayPasswordCallback(
+  onSubmit: (newPayPassword: string, walletPassword: string) => Promise<{ success: boolean; txHash?: string; error?: string }>,
+  fee?: { amount: Amount; symbol: string }
+) {
+  pendingCallback = onSubmit;
+  if (fee) {
+    feeAmount = fee.amount;
+    feeSymbol = fee.symbol;
+  }
+}
+
+/**
+ * Clear the callback (called on unmount)
+ */
+function clearSetPayPasswordCallback() {
+  pendingCallback = null;
+  feeAmount = null;
+  feeSymbol = "";
+}
+
+type SetPayPasswordJobParams = {
+  chainName?: string;
+};
+
+function SetPayPasswordJobContent() {
+  const { t } = useTranslation(["security", "transaction", "common"]);
+  const { pop } = useFlow();
+  const { chainName } = useActivityParams<SetPayPasswordJobParams>();
+
+  const [newPayPassword, setNewPayPassword] = useState("");
+  const [confirmPayPassword, setConfirmPayPassword] = useState("");
+  const [walletPassword, setWalletPassword] = useState("");
+  const [step, setStep] = useState<"input" | "confirm" | "password">("input");
+  const [error, setError] = useState<string>();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      clearSetPayPasswordCallback();
+    };
+  }, []);
+
+  const handleNextStep = useCallback(() => {
+    setError(undefined);
+    if (step === "input") {
+      if (newPayPassword.length < 6) {
+        setError(t("security:payPassword.tooShort"));
+        return;
+      }
+      setStep("confirm");
+    } else if (step === "confirm") {
+      if (newPayPassword !== confirmPayPassword) {
+        setError(t("security:payPassword.notMatch"));
+        return;
+      }
+      setStep("password");
+    }
+  }, [step, newPayPassword, confirmPayPassword, t]);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!walletPassword.trim() || !pendingCallback) return;
+
+      setIsSubmitting(true);
+      setError(undefined);
+
+      try {
+        const result = await pendingCallback(newPayPassword, walletPassword);
+        if (result.success) {
+          setSuccess(true);
+          setTimeout(() => {
+            pop();
+          }, 1500);
+        } else {
+          setError(result.error ?? t("security:payPassword.setFailed"));
+        }
+      } catch (err) {
+        setError(t("security:payPassword.setFailed"));
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [newPayPassword, walletPassword, pop, t]
+  );
+
+  const canSubmit = step === "password" && walletPassword.trim().length > 0 && !isSubmitting;
+
+  if (success) {
+    return (
+      <BottomSheet>
+        <div className="bg-background rounded-t-2xl">
+          <div className="flex justify-center py-3">
+            <div className="h-1 w-10 rounded-full bg-muted" />
+          </div>
+          <div className="flex flex-col items-center justify-center gap-4 p-8">
+            <div className="flex size-16 items-center justify-center rounded-full bg-green-100 text-green-600">
+              <Check className="size-8" />
+            </div>
+            <h2 className="text-lg font-semibold">{t("security:payPassword.setSuccess")}</h2>
+            <p className="text-center text-sm text-muted-foreground">
+              {t("security:payPassword.setSuccessDesc")}
+            </p>
+          </div>
+          <div className="h-[env(safe-area-inset-bottom)]" />
+        </div>
+      </BottomSheet>
+    );
+  }
+
+  return (
+    <BottomSheet>
+      <div className="bg-background rounded-t-2xl">
+        {/* Handle */}
+        <div className="flex justify-center py-3">
+          <div className="h-1 w-10 rounded-full bg-muted" />
+        </div>
+
+        {/* Title */}
+        <div className="border-b border-border px-4 pb-4">
+          <div className="flex items-center justify-center gap-2">
+            <Lock className="size-5 text-primary" />
+            <h2 className="text-center text-lg font-semibold">
+              {t("security:payPassword.setTitle")}
+            </h2>
+          </div>
+          {chainName && (
+            <p className="mt-1 text-center text-sm text-muted-foreground">
+              {chainName}
+            </p>
+          )}
+        </div>
+
+        {/* Content */}
+        <form onSubmit={handleSubmit} className="space-y-6 p-4">
+          {/* Fee info */}
+          {feeAmount && (
+            <div className="flex items-start gap-2 rounded-lg bg-muted/50 p-3">
+              <InfoCircle className="mt-0.5 size-4 text-muted-foreground shrink-0" />
+              <div className="text-sm text-muted-foreground">
+                <p>{t("security:payPassword.feeInfo")}</p>
+                <p className="mt-1 font-medium text-foreground">
+                  {feeAmount.toDisplayString()} {feeSymbol}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Step indicator */}
+          <div className="flex items-center justify-center gap-2">
+            <div className={cn(
+              "size-2 rounded-full",
+              step === "input" ? "bg-primary" : "bg-muted"
+            )} />
+            <div className={cn(
+              "size-2 rounded-full",
+              step === "confirm" ? "bg-primary" : "bg-muted"
+            )} />
+            <div className={cn(
+              "size-2 rounded-full",
+              step === "password" ? "bg-primary" : "bg-muted"
+            )} />
+          </div>
+
+          {step === "input" && (
+            <div className="space-y-4">
+              <p className="text-center text-sm text-muted-foreground">
+                {t("security:payPassword.inputDesc")}
+              </p>
+              <PasswordInput
+                value={newPayPassword}
+                onChange={(e) => setNewPayPassword(e.target.value)}
+                placeholder={t("security:payPassword.inputPlaceholder")}
+                aria-describedby={error ? "pay-password-error" : undefined}
+              />
+            </div>
+          )}
+
+          {step === "confirm" && (
+            <div className="space-y-4">
+              <p className="text-center text-sm text-muted-foreground">
+                {t("security:payPassword.confirmDesc")}
+              </p>
+              <PasswordInput
+                value={confirmPayPassword}
+                onChange={(e) => setConfirmPayPassword(e.target.value)}
+                placeholder={t("security:payPassword.confirmPlaceholder")}
+                aria-describedby={error ? "pay-password-error" : undefined}
+              />
+            </div>
+          )}
+
+          {step === "password" && (
+            <div className="space-y-4">
+              <p className="text-center text-sm text-muted-foreground">
+                {t("security:payPassword.walletPasswordDesc")}
+              </p>
+              <PasswordInput
+                value={walletPassword}
+                onChange={(e) => setWalletPassword(e.target.value)}
+                placeholder={t("security:payPassword.walletPasswordPlaceholder")}
+                disabled={isSubmitting}
+                aria-describedby={error ? "pay-password-error" : undefined}
+              />
+            </div>
+          )}
+
+          {error && (
+            <div id="pay-password-error" className="flex items-center gap-1.5 text-sm text-destructive">
+              <AlertCircle className="size-4" />
+              <span>{error}</span>
+            </div>
+          )}
+
+          <div className="space-y-3">
+            {step !== "password" ? (
+              <button
+                type="button"
+                onClick={handleNextStep}
+                className={cn(
+                  "w-full rounded-full py-3 font-medium text-white transition-colors",
+                  "bg-primary hover:bg-primary/90"
+                )}
+              >
+                {t("common:buttons.next")}
+              </button>
+            ) : (
+              <button
+                type="submit"
+                disabled={!canSubmit}
+                className={cn(
+                  "w-full rounded-full py-3 font-medium text-white transition-colors",
+                  "bg-primary hover:bg-primary/90",
+                  "disabled:cursor-not-allowed disabled:opacity-50"
+                )}
+              >
+                {isSubmitting ? t("common:buttons.processing") : t("common:buttons.confirm")}
+              </button>
+            )}
+
+            <button
+              type="button"
+              onClick={() => {
+                if (step === "input") {
+                  pop();
+                } else if (step === "confirm") {
+                  setStep("input");
+                  setError(undefined);
+                } else {
+                  setStep("confirm");
+                  setError(undefined);
+                }
+              }}
+              disabled={isSubmitting}
+              className="w-full py-2 text-center text-sm text-muted-foreground hover:text-foreground"
+            >
+              {step === "input" ? t("common:buttons.cancel") : t("common:buttons.back")}
+            </button>
+          </div>
+        </form>
+
+        {/* Safe area */}
+        <div className="h-[env(safe-area-inset-bottom)]" />
+      </div>
+    </BottomSheet>
+  );
+}
+
+export const SetPayPasswordJob: ActivityComponentType<SetPayPasswordJobParams> = ({ params }) => {
+  return (
+    <ActivityParamsProvider params={params}>
+      <SetPayPasswordJobContent />
+    </ActivityParamsProvider>
+  );
+};

--- a/src/stackflow/activities/sheets/index.ts
+++ b/src/stackflow/activities/sheets/index.ts
@@ -3,6 +3,7 @@ export { WalletRenameJob } from "./WalletRenameJob";
 export { WalletDeleteJob } from "./WalletDeleteJob";
 export { PasswordConfirmJob, setPasswordConfirmCallback } from "./PasswordConfirmJob";
 export { PayPasswordConfirmJob, setPayPasswordConfirmCallback } from "./PayPasswordConfirmJob";
+export { SetPayPasswordJob, setSetPayPasswordCallback } from "./SetPayPasswordJob";
 export { MnemonicOptionsJob, setMnemonicOptionsCallback } from "./MnemonicOptionsJob";
 export { ContactEditJob } from "./ContactEditJob";
 export { WalletAddJob } from "./WalletAddJob";

--- a/src/stackflow/stackflow.ts
+++ b/src/stackflow/stackflow.ts
@@ -28,7 +28,7 @@ import { AddressBookActivity } from "./activities/AddressBookActivity";
 import { NotificationsActivity } from "./activities/NotificationsActivity";
 import { StakingActivity } from "./activities/StakingActivity";
 import { WelcomeActivity } from "./activities/WelcomeActivity";
-import { ChainSelectorJob, WalletRenameJob, WalletDeleteJob, PasswordConfirmJob, PayPasswordConfirmJob, MnemonicOptionsJob, ContactEditJob, WalletAddJob, SecurityWarningJob, TransferConfirmJob } from "./activities/sheets";
+import { ChainSelectorJob, WalletRenameJob, WalletDeleteJob, PasswordConfirmJob, PayPasswordConfirmJob, SetPayPasswordJob, MnemonicOptionsJob, ContactEditJob, WalletAddJob, SecurityWarningJob, TransferConfirmJob } from "./activities/sheets";
 
 export const { Stack, useFlow, useStepFlow, activities } = stackflow({
   transitionDuration: 350,
@@ -69,6 +69,7 @@ export const { Stack, useFlow, useStepFlow, activities } = stackflow({
         WalletDeleteJob: "/job/wallet-delete/:walletId",
         PasswordConfirmJob: "/job/password-confirm",
         PayPasswordConfirmJob: "/job/pay-password-confirm",
+        SetPayPasswordJob: "/job/set-pay-password",
         MnemonicOptionsJob: "/job/mnemonic-options",
         ContactEditJob: "/job/contact-edit",
         WalletAddJob: "/job/wallet-add",
@@ -110,6 +111,7 @@ export const { Stack, useFlow, useStepFlow, activities } = stackflow({
     WalletDeleteJob,
     PasswordConfirmJob,
     PayPasswordConfirmJob,
+    SetPayPasswordJob,
     MnemonicOptionsJob,
     ContactEditJob,
     WalletAddJob,


### PR DESCRIPTION
## Summary

This PR adds pay password (二次签名/second signature) support for BioForest Chain transfers.

## Changes

### SDK Enhancements (`src/services/bioforest-sdk/index.ts`)
- Add `setPayPassword` - Create and broadcast signature transaction to set pay password
- Add `createSignatureTransaction` - Create signature transaction using SDK
- Add `getSignatureTransactionMinFee` - Get minimum fee for setting pay password

### New UI Component (`SetPayPasswordJob.tsx`)
- Three-step flow: input password → confirm → wallet password
- Fee display before confirmation
- Success/error states with proper i18n

### Helper Functions (`use-send.bioforest.ts`)
- `submitSetPayPassword` - Full flow to set pay password
- `getSetPayPasswordFee` - Get fee for setting pay password
- `hasPayPasswordSet` - Check if address has pay password

### i18n
- Added translations for zh-CN and en locales

### Testing
- Added e2e test spec for BioForest transfer flow
- Added API test script for debugging

## Testing Notes
The network API was not reachable during development (proxy issues), but all TypeScript types check and unit tests pass. Real network testing should be done when network access is restored.

## Related Issues
- Part of BioForest Chain transfer complete implementation