### PR TITLE
feat(agent): align default help behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ pnpm agent readme
 
 ```bash
 pnpm agent readme              # 启动入口（索引 + 知识地图 + 最佳实践）
+pnpm agent --help              # 查看帮助
 pnpm agent roadmap current     # 当前 Roadmap
 pnpm agent toc                 # 白皮书目录
 pnpm agent chapter <路径>       # 读取白皮书章节

--- a/openspec/changes/update-agent-help-default/proposal.md
+++ b/openspec/changes/update-agent-help-default/proposal.md
@@ -1,0 +1,13 @@
+# Change: Align agent help behavior with --help
+
+## Why
+当前 CLI 仍支持 `pnpm agent help` 且无参数时仅提示入口，而最新规范要求：帮助只能通过 `--help`，且 `pnpm agent` 无子命令时直接输出完整帮助内容。
+
+## What Changes
+- `pnpm agent` 无参数直接打印 `--help` 内容。
+- 移除 `pnpm agent help` 入口，改为提示使用 `--help`。
+- 同步相关文档与 CLI 使用说明。
+
+## Impact
+- Affected specs: agent-cli
+- Affected code: scripts/agent/cli.ts, AGENTS.md (help 指引), CLAUDE.md (入口提示), docs/white-book/附录/H-开发规范/index.md

--- a/openspec/changes/update-agent-help-default/specs/agent-cli/spec.md
+++ b/openspec/changes/update-agent-help-default/specs/agent-cli/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Agent CLI subcommands
+`pnpm agent` SHALL expose primary functions as subcommands (readme/roadmap/claim/done/create/stats/toc/chapter/epic/worktree) and provide usage help when requested.
+
+#### Scenario: Default usage
+- **WHEN** the user runs `pnpm agent` without arguments
+- **THEN** the CLI prints the same help content as `pnpm agent --help`
+
+#### Scenario: Help usage
+- **WHEN** the user runs `pnpm agent --help`
+- **THEN** the CLI prints subcommand usage说明
+
+#### Scenario: Legacy help command
+- **WHEN** the user runs `pnpm agent help`
+- **THEN** the CLI exits with an explicit message to use `--help`

--- a/openspec/changes/update-agent-help-default/tasks.md
+++ b/openspec/changes/update-agent-help-default/tasks.md
@@ -1,0 +1,4 @@
+## 1. Implementation
+- [x] 1.1 调整 CLI 默认行为与 help 入口
+- [x] 1.2 更新文档中 help 命令指引
+- [x] 1.3 验证：运行 `pnpm agent` 与 `pnpm agent --help`

--- a/scripts/agent/cli.ts
+++ b/scripts/agent/cli.ts
@@ -46,6 +46,7 @@ AI Agent CLI
 
 Usage:
   pnpm agent readme                          # 输出索引（最佳实践 + 知识地图）
+  pnpm agent --help                          # 查看帮助
   pnpm agent roadmap [current|v1|v2|draft]   # 查看任务列表
   pnpm agent claim <issue#>                  # 领取任务（分配给自己）
   pnpm agent done <issue#>                   # 完成任务（关闭 Issue）
@@ -79,13 +80,6 @@ Examples:
   pnpm agent epic create "大功能" --roadmap v1 --issues 44,45,46
   pnpm agent worktree create issue-28 --branch feat/issue-28
 `)
-}
-
-function printEntryHint(): void {
-  console.log(`\nAI Agent CLI\n`)
-  console.log('请使用子命令启动：')
-  console.log('  pnpm agent readme')
-  console.log('  pnpm agent help\n')
 }
 
 function getFlagValue(args: string[], flag: string): string | undefined {
@@ -265,11 +259,11 @@ function main(): void {
   const args = process.argv.slice(2)
 
   if (args.length === 0) {
-    printEntryHint()
+    printHelp()
     return
   }
 
-  if (args.includes('--help') || args.includes('-h') || args[0] === 'help') {
+  if (args.includes('--help') || args.includes('-h')) {
     printHelp()
     return
   }
@@ -348,6 +342,12 @@ function main(): void {
 
     case 'worktree':
       handleWorktree(rest)
+      break
+
+    case 'help':
+      log.error('请使用 --help 查看帮助')
+      printHelp()
+      process.exit(1)
       break
 
     default:


### PR DESCRIPTION
## Summary\n- default pnpm agent prints full --help output\n- help subcommand now points to --help\n- update AGENTS usage to reference --help\n\n## Testing\n- pnpm agent\n- pnpm agent --help\n- pnpm agent help (expects error)\n- openspec validate update-agent-help-default --strict