### PR TITLE
fix(cd): clean dist directories before rename on self-hosted runner

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -97,9 +97,11 @@ jobs:
           
           # 构建 Web 和 DWEB 版本
           SERVICE_IMPL=web pnpm build
+          rm -rf dist-web
           mv dist dist-web
           
           SERVICE_IMPL=dweb pnpm build
+          rm -rf dist-dweb
           mv dist dist-dweb
           
           # Plaoc bundle


### PR DESCRIPTION
## Problem
CD workflow fails on self-hosted runner with error:
```
mv: rename dist to dist-web/dist: Directory not empty
```

This happens because `dist-web` and `dist-dweb` directories from previous builds are not cleaned up.

## Solution
Add `rm -rf` before `mv` to ensure the target directories don't exist.