### PR TITLE
fix(icons): resolve icon paths relative to JSON config file

### DIFF
--- a/public/configs/default-chains.json
+++ b/public/configs/default-chains.json
@@ -5,9 +5,9 @@
     "type": "bioforest",
     "name": "BFMeta",
     "symbol": "BFM",
-    "icon": "/icons/bfmeta/chain.svg",
+    "icon": "../icons/bfmeta/chain.svg",
     "tokenIconBase": [
-      "/icons/bfmeta/tokens",
+      "../icons/bfmeta/tokens",
       "https://bfm-fonts-cdn.oss-cn-hongkong.aliyuncs.com/meta-icon/bfm",
       "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/bfm"
     ],
@@ -27,9 +27,9 @@
     "type": "bioforest",
     "name": "CCChain",
     "symbol": "CCC",
-    "icon": "/icons/ccchain/chain.svg",
+    "icon": "../icons/ccchain/chain.svg",
     "tokenIconBase": [
-      "/icons/ccchain/tokens",
+      "../icons/ccchain/tokens",
       "https://bfm-fonts-cdn.oss-cn-hongkong.aliyuncs.com/meta-icon/ccc",
       "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/ccc"
     ],
@@ -43,9 +43,9 @@
     "type": "bioforest",
     "name": "PMChain",
     "symbol": "PMC",
-    "icon": "/icons/pmchain/chain.svg",
+    "icon": "../icons/pmchain/chain.svg",
     "tokenIconBase": [
-      "/icons/pmchain/tokens",
+      "../icons/pmchain/tokens",
       "https://bfm-fonts-cdn.oss-cn-hongkong.aliyuncs.com/meta-icon/pmc",
       "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/pmc"
     ],
@@ -59,9 +59,9 @@
     "type": "bioforest",
     "name": "BFChain V2",
     "symbol": "BFT",
-    "icon": "/icons/bfchainv2/chain.svg",
+    "icon": "../icons/bfchainv2/chain.svg",
     "tokenIconBase": [
-      "/icons/bfchainv2/tokens",
+      "../icons/bfchainv2/tokens",
       "https://bfm-fonts-cdn.oss-cn-hongkong.aliyuncs.com/meta-icon/bftv2",
       "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/bftv2"
     ],
@@ -75,9 +75,9 @@
     "type": "bioforest",
     "name": "BTGMeta",
     "symbol": "BTGM",
-    "icon": "/icons/btgmeta/chain.svg",
+    "icon": "../icons/btgmeta/chain.svg",
     "tokenIconBase": [
-      "/icons/btgmeta/tokens",
+      "../icons/btgmeta/tokens",
       "https://bfm-fonts-cdn.oss-cn-hongkong.aliyuncs.com/meta-icon/btgm",
       "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/btgm"
     ],
@@ -105,9 +105,9 @@
     "type": "bioforest",
     "name": "ETHMeta",
     "symbol": "ETHM",
-    "icon": "/icons/ethmeta/chain.svg",
+    "icon": "../icons/ethmeta/chain.svg",
     "tokenIconBase": [
-      "/icons/ethmeta/tokens",
+      "../icons/ethmeta/tokens",
       "https://bfm-fonts-cdn.oss-cn-hongkong.aliyuncs.com/meta-icon/ethm",
       "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/ethm"
     ],
@@ -135,9 +135,9 @@
     "type": "evm",
     "name": "Ethereum",
     "symbol": "ETH",
-    "icon": "/icons/ethereum/chain.svg",
+    "icon": "../icons/ethereum/chain.svg",
     "tokenIconBase": [
-      "/icons/ethereum/tokens",
+      "../icons/ethereum/tokens",
       "https://bfm-fonts-cdn.oss-cn-hongkong.aliyuncs.com/meta-icon/eth",
       "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/eth"
     ],
@@ -151,9 +151,9 @@
     "type": "evm",
     "name": "BNB Smart Chain",
     "symbol": "BNB",
-    "icon": "/icons/binance/chain.svg",
+    "icon": "../icons/binance/chain.svg",
     "tokenIconBase": [
-      "/icons/binance/tokens",
+      "../icons/binance/tokens",
       "https://bfm-fonts-cdn.oss-cn-hongkong.aliyuncs.com/meta-icon/bsc",
       "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/bsc"
     ],
@@ -167,9 +167,9 @@
     "type": "bip39",
     "name": "Tron",
     "symbol": "TRX",
-    "icon": "/icons/tron/chain.svg",
+    "icon": "../icons/tron/chain.svg",
     "tokenIconBase": [
-      "/icons/tron/tokens",
+      "../icons/tron/tokens",
       "https://bfm-fonts-cdn.oss-cn-hongkong.aliyuncs.com/meta-icon/tron",
       "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/tron"
     ],
@@ -183,9 +183,9 @@
     "type": "bip39",
     "name": "Bitcoin",
     "symbol": "BTC",
-    "icon": "/icons/bitcoin/chain.svg",
+    "icon": "../icons/bitcoin/chain.svg",
     "tokenIconBase": [
-      "/icons/bitcoin/tokens",
+      "../icons/bitcoin/tokens",
       "https://bfm-fonts-cdn.oss-cn-hongkong.aliyuncs.com/meta-icon/btcm",
       "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/btcm"
     ],

--- a/src/components/wallet/token-icon.tsx
+++ b/src/components/wallet/token-icon.tsx
@@ -49,11 +49,30 @@ export interface TokenIconProps {
 }
 
 /**
+ * 检查 URL 是否是同源的（本地资源）
+ */
+function isSameOrigin(url: string): boolean {
+  // 相对路径视为同源
+  if (url.startsWith('/') || url.startsWith('./') || url.startsWith('../')) {
+    return true
+  }
+  // 检查是否与当前页面同源
+  try {
+    const urlObj = new URL(url)
+    return urlObj.origin === window.location.origin
+  } catch {
+    return true // 解析失败视为相对路径
+  }
+}
+
+/**
  * 根据 base 路径和 symbol 生成图标 URL
+ * - 本地资源（同源）：使用 {symbol}.svg 格式
+ * - CDN 资源（跨域）：使用 icon-{symbol}.png 格式
  */
 function buildIconUrl(base: string, symbol: string): string {
   const lowerSymbol = symbol.toLowerCase();
-  if (base.startsWith('/') || base.startsWith('./')) {
+  if (isSameOrigin(base)) {
     return `${base}/${lowerSymbol}.svg`;
   }
   return `${base}/icon-${lowerSymbol}.png`;


### PR DESCRIPTION
## Problem
Icon paths like `/icons/bfchainv2/tokens/bft.svg` fail when deployed to subpaths (e.g., `/KeyApp/webapp/`).

## Solution
Resolve icon paths relative to the JSON config file location instead of document.baseURI:

- Add `resolveRelativePath()` and `resolveIconPaths()` in chain-config service
- Paths are resolved when loading JSON, using the JSON file URL as base
- Add `isSameOrigin()` in token-icon to distinguish local (.svg) vs CDN (icon-*.png) resources
- Update default-chains.json to use relative paths (`../icons/...`)

## Changes
- `src/services/chain-config/index.ts`: Add path resolution logic
- `src/components/wallet/token-icon.tsx`: Add same-origin detection
- `public/configs/default-chains.json`: Use relative paths

Closes the 404 issue for token icons on GitHub Pages.