### PR TITLE
fix(scanner): always render video element to avoid race condition

### DIFF
--- a/src/pages/scanner/index.tsx
+++ b/src/pages/scanner/index.tsx
@@ -304,9 +304,16 @@ export function ScannerPage({ onScan, className }: ScannerPageProps) {
 
       {/* Camera viewfinder */}
       <div className="relative flex-1">
-        {(state === 'scanning' || state === 'success') && (
-          <video ref={videoRef} className="absolute inset-0 size-full object-cover" playsInline muted />
-        )}
+        {/* Video 始终渲染，避免 srcObject 设置时元素不存在的 race condition */}
+        <video
+          ref={videoRef}
+          className={cn(
+            'absolute inset-0 size-full object-cover',
+            state !== 'scanning' && state !== 'success' && 'invisible'
+          )}
+          playsInline
+          muted
+        />
 
         {/* Scan overlay */}
         <div className="absolute inset-0 flex items-center justify-center">


### PR DESCRIPTION
## Problem
Camera video doesn't render on GitHub Pages, but works locally.

## Root Cause
Race condition: video element was conditionally rendered based on state:
```tsx
{(state === 'scanning' || state === 'success') && (
  <video ref={videoRef} ... />
)}
```

But `initCamera` tried to set `srcObject` before state changed:
```tsx
videoRef.current.srcObject = stream;  // videoRef.current is null!
setState('scanning');  // video renders AFTER this
```

## Solution
Always render the video element, use CSS `invisible` class to hide it when not active. This ensures `videoRef.current` is available when `initCamera` runs.