### PR TITLE
fix(docs): correct dead links in web3-adapters.md

### DIFF
--- a/docs/white-book/04-服务篇/02-链服务/实现规范/02-web3-adapters.md
+++ b/docs/white-book/04-服务篇/02-链服务/实现规范/02-web3-adapters.md
@@ -204,6 +204,6 @@ pnpm test -- --testPathPattern="chain-adapter"
 
 ## 相关文档
 
-- [链配置管理](../07-链配置管理/index.md)
-- [测试网络](../../08-测试篇/06-测试网络/index.md)
+- [链配置管理](../../07-链配置管理/index.md)
+- [测试网络](../../../08-测试篇/06-测试网络/index.md)
 - [ITransactionService](../ITransactionService.md)


### PR DESCRIPTION
修复 VitePress 构建失败的死链问题

### 问题
CD 流水线因 VitePress 检测到死链而失败：
- `../07-链配置管理/index.md` → 应为 `../../07-链配置管理/index.md`
- `../../08-测试篇/06-测试网络/index.md` → 应为 `../../../08-测试篇/06-测试网络/index.md`

### 修复
修正相对路径层级