### PR TITLE
fix(cd): use git push for GitHub Pages deploy on self-hosted runner

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,14 +42,6 @@ jobs:
       channel: ${{ steps.channel.outputs.channel }}
 
     steps:
-      - name: Setup GNU tar (required for actions/upload-pages-artifact)
-        run: |
-          # macOS uses BSD tar by default, but upload-pages-artifact requires GNU tar (gtar)
-          if ! command -v gtar &> /dev/null; then
-            brew install gnu-tar
-          fi
-          echo "$(brew --prefix gnu-tar)/libexec/gnubin" >> $GITHUB_PATH
-
       - name: Git checkout
         run: |
           if [ ! -d ".git" ]; then
@@ -176,10 +168,19 @@ jobs:
             cp release/bfmpay-dweb-beta.zip "release/bfmpay-dweb-${VERSION}-beta.zip"
           fi
 
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: gh-pages
+      # 直接推送到 gh-pages 分支，避免使用 upload-pages-artifact（self-hosted 上容易卡住）
+      - name: Deploy to GitHub Pages
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          cd gh-pages
+          git init
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Deploy to GitHub Pages - ${{ github.sha }}"
+          git push -f "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" HEAD:gh-pages
+          echo "Deployed to gh-pages branch"
 
       # 直接在 build job 中创建 release，避免跨 job 传递 artifact（self-hosted 下载很慢）
       - name: Create or Update Release
@@ -426,21 +427,8 @@ jobs:
           path: release/
           retention-days: 30
 
-  # ==================== 部署到 GitHub Pages ====================
-  deploy-pages-fast:
-    if: vars.USE_SELF_HOSTED == 'true'
-    needs: build-fast
-    runs-on: self-hosted
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-
+  # ==================== 部署到 GitHub Pages (GitHub-hosted only) ====================
+  # Self-hosted 版本直接在 build-fast 中用 git push 部署，避免 upload-pages-artifact 卡住
   deploy-pages-standard:
     if: vars.USE_SELF_HOSTED != 'true'
     needs: build-standard


### PR DESCRIPTION
## Problem

`actions/upload-pages-artifact@v3` 在 self-hosted runner 上容易卡住，导致 CD 部署失败。

## Solution

对于 self-hosted runner，改用直接 git push 到 `gh-pages` 分支的方式部署：

- 移除 `actions/upload-pages-artifact` 步骤
- 移除 `deploy-pages-fast` job
- 在 `build-fast` job 中直接 git push 到 `gh-pages` 分支
- 移除不再需要的 GNU tar 安装步骤

## Note

合并后需要在 GitHub 仓库设置中配置 Pages 部署源为 `gh-pages` 分支：
Settings -> Pages -> Build and deployment -> Source: Deploy from a branch -> Branch: gh-pages

GitHub-hosted runner 路径保持不变（使用 actions/deploy-pages）。