### PR TITLE
chore: add webapp-beta and webapp-alpha to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ docs/.vitepress/dist
 docs/.vitepress/cache
 docs/public/webapp
 docs/public/webapp-dev
+docs/public/webapp-beta
+docs/public/webapp-alpha
 
 # dependencies
 node_modules


### PR DESCRIPTION
Reserve paths for future beta/alpha channels.

Currently using webapp-dev, but keeping beta/alpha paths available for future use.