### PR TITLE
fix(scripts): add checkbox hint and required validation for set-secret

### DIFF
--- a/scripts/set-secret.ts
+++ b/scripts/set-secret.ts
@@ -379,17 +379,13 @@ ${colors.cyan}╔═════════════════════
 
   // 选择要配置的类别
   const selectedCategories = await checkbox({
-    message: '选择要配置的项目:',
+    message: '选择要配置的项目 (空格选中，回车确认):',
     choices: CATEGORIES.map((c) => ({
       value: c.id,
       name: `${c.name} - ${c.description}`,
     })),
+    required: true,
   })
-
-  if (selectedCategories.length === 0) {
-    log.info('未选择任何配置项')
-    return
-  }
 
   // 选择配置目标
   const target = await select({


### PR DESCRIPTION
## 问题
`pnpm set-secret` 在用户选择后立即退出，因为 checkbox 需要先按 Space 选中再按 Enter 确认，用户不知道这个操作方式。

## 修复
- 添加操作提示 `(空格选中，回车确认)`
- 添加 `required: true` 强制至少选中一项
- 移除冗余的空数组检查（required 已保证不为空）