### PR TITLE
feat: 添加地址余额/交易查询功能

### DIFF
--- a/src/components/wallet/wallet-card-carousel.tsx
+++ b/src/components/wallet/wallet-card-carousel.tsx
@@ -8,7 +8,13 @@ import { useWalletTheme } from '@/hooks/useWalletTheme';
 import { useChainIconUrls } from '@/hooks/useChainIconUrls';
 import { cn } from '@/lib/utils';
 import type { Wallet, ChainType } from '@/stores';
-import { IconWallet, IconPlus } from '@tabler/icons-react';
+import { IconWallet, IconPlus, IconDotsVertical, IconSearch, IconReceipt } from '@tabler/icons-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 import 'swiper/css';
 import 'swiper/css/effect-cards';
@@ -26,6 +32,8 @@ interface WalletCardCarouselProps {
   onOpenSettings?: (walletId: string) => void;
   onOpenWalletList?: () => void;
   onAddWallet?: () => void;
+  onOpenAddressBalance?: () => void;
+  onOpenAddressTransactions?: () => void;
   className?: string;
 }
 
@@ -45,6 +53,8 @@ export function WalletCardCarousel({
   onOpenSettings,
   onOpenWalletList,
   onAddWallet,
+  onOpenAddressBalance,
+  onOpenAddressTransactions,
   className,
 }: WalletCardCarouselProps) {
   const swiperRef = useRef<SwiperType | null>(null);
@@ -111,15 +121,40 @@ export function WalletCardCarousel({
         </button>
       )}
 
-      {/* 右上角：添加钱包 */}
-      {onAddWallet && (
-        <button
-          onClick={onAddWallet}
-          className="bg-primary text-primary-foreground hover:bg-primary/90 absolute top-0 right-4 z-10 flex items-center justify-center rounded-full p-1.5 backdrop-blur-sm transition-colors"
-        >
-          <IconPlus className="size-4" />
-        </button>
-      )}
+      {/* 右上角：添加钱包 + 更多菜单 */}
+      <div className="absolute top-0 right-4 z-10 flex items-center gap-1.5">
+        {onAddWallet && (
+          <button
+            onClick={onAddWallet}
+            className="bg-primary text-primary-foreground hover:bg-primary/90 flex items-center justify-center rounded-full p-1.5 backdrop-blur-sm transition-colors"
+          >
+            <IconPlus className="size-4" />
+          </button>
+        )}
+        {(onOpenAddressBalance || onOpenAddressTransactions) && (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              className="bg-primary text-primary-foreground hover:bg-primary/90 flex items-center justify-center rounded-full p-1.5 backdrop-blur-sm transition-colors"
+            >
+              <IconDotsVertical className="size-4" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" sideOffset={8}>
+              {onOpenAddressBalance && (
+                <DropdownMenuItem onClick={onOpenAddressBalance}>
+                  <IconSearch className="size-4" />
+                  地址余额查询
+                </DropdownMenuItem>
+              )}
+              {onOpenAddressTransactions && (
+                <DropdownMenuItem onClick={onOpenAddressTransactions}>
+                  <IconReceipt className="size-4" />
+                  地址交易查询
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
 
       <Swiper
         modules={[EffectCards]}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -352,5 +352,20 @@
     "daysLater": "In {{count}} days",
     "today": "Today",
     "yesterday": "Yesterday"
+  },
+  "addressLookup": {
+    "balanceTitle": "Address Balance",
+    "transactionsTitle": "Address Transactions",
+    "chain": "Chain",
+    "address": "Address",
+    "addressPlaceholder": "Enter wallet address",
+    "addressOrHash": "Address or Transaction Hash",
+    "addressOrHashPlaceholder": "Enter address or tx hash",
+    "otherChains": "Other Chains",
+    "error": "Query Failed",
+    "onChain": "on {{chain}}",
+    "explorerHint": "Transaction history requires block explorer",
+    "openExplorer": "Open {{name}} Explorer",
+    "viewOnExplorer": "View on {{name}}"
   }
 }

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -330,5 +330,20 @@
     "daysLater": "{{count}} 天后",
     "today": "今天",
     "yesterday": "昨天"
+  },
+  "addressLookup": {
+    "balanceTitle": "地址余额查询",
+    "transactionsTitle": "地址交易查询",
+    "chain": "链",
+    "address": "地址",
+    "addressPlaceholder": "输入钱包地址",
+    "addressOrHash": "地址或交易哈希",
+    "addressOrHashPlaceholder": "输入地址或交易哈希",
+    "otherChains": "其他链",
+    "error": "查询失败",
+    "onChain": "在 {{chain}} 上",
+    "explorerHint": "交易记录需要通过区块浏览器查询",
+    "openExplorer": "打开 {{name}} 浏览器",
+    "viewOnExplorer": "在 {{name}} 浏览器中查看"
   }
 }

--- a/src/pages/address-balance/index.tsx
+++ b/src/pages/address-balance/index.tsx
@@ -1,0 +1,154 @@
+import { useState, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigation } from '@/stackflow'
+import { PageHeader } from '@/components/layout/page-header'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Card, CardContent } from '@/components/ui/card'
+import { LoadingSpinner } from '@/components/common/loading-spinner'
+import { useAddressBalanceQuery } from '@/queries/use-address-balance-query'
+import { useEnabledChains } from '@/stores'
+import { IconSearch, IconAlertCircle, IconCurrencyEthereum } from '@tabler/icons-react'
+import { cn } from '@/lib/utils'
+
+export function AddressBalancePage() {
+  const { t } = useTranslation(['common', 'wallet'])
+  const { goBack } = useNavigation()
+  const enabledChains = useEnabledChains()
+
+  const [selectedChain, setSelectedChain] = useState('ethereum')
+  const [address, setAddress] = useState('')
+  const [queryAddress, setQueryAddress] = useState('')
+  const [queryChain, setQueryChain] = useState('')
+
+  const { data, isLoading, isFetching } = useAddressBalanceQuery(
+    queryChain,
+    queryAddress,
+    !!queryChain && !!queryAddress
+  )
+
+  const handleSearch = useCallback(() => {
+    if (address.trim()) {
+      setQueryAddress(address.trim())
+      setQueryChain(selectedChain)
+    }
+  }, [address, selectedChain])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        handleSearch()
+      }
+    },
+    [handleSearch]
+  )
+
+  const evmChains = enabledChains.filter((c) => c.type === 'evm')
+  const otherChains = enabledChains.filter((c) => c.type !== 'evm')
+
+  return (
+    <div className="bg-background flex min-h-screen flex-col">
+      <PageHeader title={t('common:addressLookup.balanceTitle')} onBack={goBack} />
+
+      <div className="flex-1 space-y-4 p-4">
+        {/* Chain Selector */}
+        <div className="space-y-2">
+          <Label>{t('common:addressLookup.chain')}</Label>
+          <Select value={selectedChain} onValueChange={setSelectedChain}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {evmChains.length > 0 && (
+                <>
+                  <div className="text-muted-foreground px-2 py-1.5 text-xs font-medium">EVM</div>
+                  {evmChains.map((chain) => (
+                    <SelectItem key={chain.id} value={chain.id}>
+                      {chain.name}
+                    </SelectItem>
+                  ))}
+                </>
+              )}
+              {otherChains.length > 0 && (
+                <>
+                  <div className="text-muted-foreground px-2 py-1.5 text-xs font-medium">
+                    {t('common:addressLookup.otherChains')}
+                  </div>
+                  {otherChains.map((chain) => (
+                    <SelectItem key={chain.id} value={chain.id}>
+                      {chain.name}
+                    </SelectItem>
+                  ))}
+                </>
+              )}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Address Input */}
+        <div className="space-y-2">
+          <Label>{t('common:addressLookup.address')}</Label>
+          <div className="flex gap-2">
+            <Input
+              placeholder={t('common:addressLookup.addressPlaceholder')}
+              value={address}
+              onChange={(e) => setAddress(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="flex-1 font-mono text-sm"
+            />
+            <Button onClick={handleSearch} disabled={!address.trim() || isFetching}>
+              {isFetching ? <LoadingSpinner size="sm" /> : <IconSearch className="size-4" />}
+            </Button>
+          </div>
+        </div>
+
+        {/* Result */}
+        {queryAddress && (
+          <Card className={cn('transition-all', isLoading && 'opacity-50')}>
+            <CardContent className="pt-6">
+              {data?.error ? (
+                <div className="flex items-center gap-3 text-destructive">
+                  <IconAlertCircle className="size-5 shrink-0" />
+                  <div>
+                    <div className="font-medium">{t('common:addressLookup.error')}</div>
+                    <div className="text-sm opacity-80">{data.error}</div>
+                  </div>
+                </div>
+              ) : data?.balance ? (
+                <div className="flex items-center gap-3">
+                  <div className="bg-primary/10 flex size-12 items-center justify-center rounded-full">
+                    <IconCurrencyEthereum className="text-primary size-6" />
+                  </div>
+                  <div>
+                    <div className="text-2xl font-bold">
+                      {data.balance.amount.toFormatted()} {data.balance.symbol}
+                    </div>
+                    <div className="text-muted-foreground text-sm">
+                      {t('common:addressLookup.onChain', {
+                        chain: enabledChains.find((c) => c.id === queryChain)?.name ?? queryChain,
+                      })}
+                    </div>
+                  </div>
+                </div>
+              ) : isLoading ? (
+                <div className="flex items-center justify-center py-4">
+                  <LoadingSpinner size="lg" />
+                </div>
+              ) : null}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Debug Info (DEV only) */}
+        {import.meta.env.DEV && queryAddress && (
+          <div className="text-muted-foreground rounded-lg bg-muted/50 p-3 font-mono text-xs">
+            <div>Chain: {queryChain}</div>
+            <div className="truncate">Address: {queryAddress}</div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/address-transactions/index.tsx
+++ b/src/pages/address-transactions/index.tsx
@@ -1,0 +1,165 @@
+import { useState, useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useNavigation } from '@/stackflow'
+import { PageHeader } from '@/components/layout/page-header'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Card, CardContent } from '@/components/ui/card'
+import { useEnabledChains } from '@/stores'
+import { IconSearch, IconExternalLink, IconInfoCircle } from '@tabler/icons-react'
+
+export function AddressTransactionsPage() {
+  const { t } = useTranslation(['common', 'wallet'])
+  const { goBack } = useNavigation()
+  const enabledChains = useEnabledChains()
+
+  const [selectedChain, setSelectedChain] = useState('ethereum')
+  const [address, setAddress] = useState('')
+
+  const selectedChainConfig = useMemo(
+    () => enabledChains.find((c) => c.id === selectedChain),
+    [enabledChains, selectedChain]
+  )
+
+  const explorerUrl = useMemo(() => {
+    if (!selectedChainConfig?.explorer || !address.trim()) return null
+
+    const { queryAddress, url } = selectedChainConfig.explorer
+    if (queryAddress) {
+      return queryAddress.replace(':address', address.trim())
+    }
+    // Fallback: common explorer patterns
+    if (url.includes('etherscan')) {
+      return `${url}/address/${address.trim()}`
+    }
+    if (url.includes('bscscan')) {
+      return `${url}/address/${address.trim()}`
+    }
+    if (url.includes('tronscan')) {
+      return `${url}/#/address/${address.trim()}`
+    }
+    return `${url}/address/${address.trim()}`
+  }, [selectedChainConfig, address])
+
+  const handleOpenExplorer = useCallback(() => {
+    if (explorerUrl) {
+      window.open(explorerUrl, '_blank', 'noopener,noreferrer')
+    }
+  }, [explorerUrl])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && explorerUrl) {
+        handleOpenExplorer()
+      }
+    },
+    [explorerUrl, handleOpenExplorer]
+  )
+
+  const evmChains = enabledChains.filter((c) => c.type === 'evm')
+  const otherChains = enabledChains.filter((c) => c.type !== 'evm')
+
+  return (
+    <div className="bg-background flex min-h-screen flex-col">
+      <PageHeader title={t('common:addressLookup.transactionsTitle')} onBack={goBack} />
+
+      <div className="flex-1 space-y-4 p-4">
+        {/* Chain Selector */}
+        <div className="space-y-2">
+          <Label>{t('common:addressLookup.chain')}</Label>
+          <Select value={selectedChain} onValueChange={setSelectedChain}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {evmChains.length > 0 && (
+                <>
+                  <div className="text-muted-foreground px-2 py-1.5 text-xs font-medium">EVM</div>
+                  {evmChains.map((chain) => (
+                    <SelectItem key={chain.id} value={chain.id}>
+                      {chain.name}
+                    </SelectItem>
+                  ))}
+                </>
+              )}
+              {otherChains.length > 0 && (
+                <>
+                  <div className="text-muted-foreground px-2 py-1.5 text-xs font-medium">
+                    {t('common:addressLookup.otherChains')}
+                  </div>
+                  {otherChains.map((chain) => (
+                    <SelectItem key={chain.id} value={chain.id}>
+                      {chain.name}
+                    </SelectItem>
+                  ))}
+                </>
+              )}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Address Input */}
+        <div className="space-y-2">
+          <Label>{t('common:addressLookup.addressOrHash')}</Label>
+          <div className="flex gap-2">
+            <Input
+              placeholder={t('common:addressLookup.addressOrHashPlaceholder')}
+              value={address}
+              onChange={(e) => setAddress(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="flex-1 font-mono text-sm"
+            />
+            <Button onClick={handleOpenExplorer} disabled={!explorerUrl}>
+              <IconSearch className="size-4" />
+            </Button>
+          </div>
+        </div>
+
+        {/* Info Card */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-start gap-3">
+              <IconInfoCircle className="text-muted-foreground mt-0.5 size-5 shrink-0" />
+              <div className="space-y-3">
+                <p className="text-muted-foreground text-sm">
+                  {t('common:addressLookup.explorerHint')}
+                </p>
+                {selectedChainConfig?.explorer?.url && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-2"
+                    onClick={() =>
+                      window.open(selectedChainConfig.explorer!.url, '_blank', 'noopener,noreferrer')
+                    }
+                  >
+                    <IconExternalLink className="size-4" />
+                    {t('common:addressLookup.openExplorer', {
+                      name: selectedChainConfig.name,
+                    })}
+                  </Button>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Quick Links */}
+        {address.trim() && explorerUrl && (
+          <Card className="border-primary/20 bg-primary/5">
+            <CardContent className="pt-6">
+              <Button className="w-full gap-2" onClick={handleOpenExplorer}>
+                <IconExternalLink className="size-4" />
+                {t('common:addressLookup.viewOnExplorer', {
+                  name: selectedChainConfig?.name ?? selectedChain,
+                })}
+              </Button>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -58,3 +58,9 @@ export {
   securityPasswordQueryKeys,
   type SecurityPasswordQueryResult,
 } from './use-security-password-query'
+
+export {
+  useAddressBalanceQuery,
+  addressBalanceKeys,
+  type AddressBalanceResult,
+} from './use-address-balance-query'

--- a/src/queries/use-address-balance-query.ts
+++ b/src/queries/use-address-balance-query.ts
@@ -1,0 +1,63 @@
+import { useQuery } from '@tanstack/react-query'
+import { getAdapterRegistry, setupAdapters } from '@/services/chain-adapter'
+import { chainConfigStore, chainConfigSelectors } from '@/stores'
+import type { Balance } from '@/services/chain-adapter/types'
+
+let adaptersInitialized = false
+function ensureAdapters() {
+  if (!adaptersInitialized) {
+    setupAdapters()
+    adaptersInitialized = true
+  }
+}
+
+export const addressBalanceKeys = {
+  all: ['addressBalance'] as const,
+  query: (chainId: string, address: string) => ['addressBalance', chainId, address] as const,
+}
+
+export interface AddressBalanceResult {
+  balance: Balance | null
+  error: string | null
+}
+
+/**
+ * Query hook for fetching balance of any address on any chain
+ */
+export function useAddressBalanceQuery(chainId: string, address: string, enabled = true) {
+  return useQuery({
+    queryKey: addressBalanceKeys.query(chainId, address),
+    queryFn: async (): Promise<AddressBalanceResult> => {
+      if (!chainId || !address) {
+        return { balance: null, error: 'Missing chain or address' }
+      }
+
+      try {
+        ensureAdapters()
+
+        const state = chainConfigStore.state
+        const chainConfig = chainConfigSelectors.getChainById(state, chainId)
+        if (!chainConfig) {
+          return { balance: null, error: `Unknown chain: ${chainId}` }
+        }
+
+        const registry = getAdapterRegistry()
+        registry.setChainConfigs([chainConfig])
+
+        const adapter = registry.getAdapter(chainId)
+        if (!adapter) {
+          return { balance: null, error: `No adapter for chain: ${chainId}` }
+        }
+
+        const balance = await adapter.asset.getNativeBalance(address)
+        return { balance, error: null }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return { balance: null, error: message }
+      }
+    },
+    enabled: enabled && !!chainId && !!address,
+    staleTime: 30 * 1000,
+    gcTime: 5 * 60 * 1000,
+  })
+}

--- a/src/stackflow/activities/AddressBalanceActivity.tsx
+++ b/src/stackflow/activities/AddressBalanceActivity.tsx
@@ -1,0 +1,11 @@
+import type { ActivityComponentType } from '@stackflow/react'
+import { AppScreen } from '@stackflow/plugin-basic-ui'
+import { AddressBalancePage } from '@/pages/address-balance'
+
+export const AddressBalanceActivity: ActivityComponentType = () => {
+  return (
+    <AppScreen>
+      <AddressBalancePage />
+    </AppScreen>
+  )
+}

--- a/src/stackflow/activities/AddressTransactionsActivity.tsx
+++ b/src/stackflow/activities/AddressTransactionsActivity.tsx
@@ -1,0 +1,11 @@
+import type { ActivityComponentType } from '@stackflow/react'
+import { AppScreen } from '@stackflow/plugin-basic-ui'
+import { AddressTransactionsPage } from '@/pages/address-transactions'
+
+export const AddressTransactionsActivity: ActivityComponentType = () => {
+  return (
+    <AppScreen>
+      <AddressTransactionsPage />
+    </AppScreen>
+  )
+}

--- a/src/stackflow/activities/tabs/WalletTab.tsx
+++ b/src/stackflow/activities/tabs/WalletTab.tsx
@@ -128,6 +128,16 @@ export function WalletTab() {
     push("WalletListJob", {});
   }, [push]);
 
+  // 地址余额查询
+  const handleOpenAddressBalance = useCallback(() => {
+    push("AddressBalanceActivity", {});
+  }, [push]);
+
+  // 地址交易查询
+  const handleOpenAddressTransactions = useCallback(() => {
+    push("AddressTransactionsActivity", {});
+  }, [push]);
+
   // 交易点击
   const handleTransactionClick = useCallback(
     (tx: TransactionInfo) => {
@@ -166,6 +176,8 @@ export function WalletTab() {
           onOpenSettings={handleOpenWalletSettings}
           onOpenWalletList={handleOpenWalletList}
           onAddWallet={handleAddWallet}
+          onOpenAddressBalance={handleOpenAddressBalance}
+          onOpenAddressTransactions={handleOpenAddressTransactions}
         />
 
         {/* 快捷操作按钮 - 颜色跟随主题 */}

--- a/src/stackflow/stackflow.ts
+++ b/src/stackflow/stackflow.ts
@@ -31,6 +31,8 @@ import { SettingsWalletChainsActivity } from './activities/SettingsWalletChainsA
 import { SettingsStorageActivity } from './activities/SettingsStorageActivity';
 import { SettingsSourcesActivity } from './activities/SettingsSourcesActivity';
 import { MiniappDetailActivity } from './activities/MiniappDetailActivity';
+import { AddressBalanceActivity } from './activities/AddressBalanceActivity';
+import { AddressTransactionsActivity } from './activities/AddressTransactionsActivity';
 import {
   ChainSelectorJob,
   WalletRenameJob,
@@ -94,6 +96,8 @@ export const { Stack, useFlow, useStepFlow, activities } = stackflow({
         WelcomeActivity: '/welcome',
         SettingsSourcesActivity: '/settings/sources',
         MiniappDetailActivity: '/miniapp/:appId/detail',
+        AddressBalanceActivity: '/address-balance',
+        AddressTransactionsActivity: '/address-transactions',
         ChainSelectorJob: '/job/chain-selector',
         WalletRenameJob: '/job/wallet-rename/:walletId',
         WalletDeleteJob: '/job/wallet-delete/:walletId',
@@ -155,6 +159,8 @@ export const { Stack, useFlow, useStepFlow, activities } = stackflow({
     WelcomeActivity,
     SettingsSourcesActivity,
     MiniappDetailActivity,
+    AddressBalanceActivity,
+    AddressTransactionsActivity,
     ChainSelectorJob,
     WalletRenameJob,
     WalletDeleteJob,


### PR DESCRIPTION
## 概述

添加地址余额查询和交易查询页面，方便诊断客户资产显示问题。

## 变更内容

### 新增页面
- **地址余额查询页面** (AddressBalancePage): 支持选择链、输入地址后查询余额
- **地址交易查询页面** (AddressTransactionsPage): 输入地址后跳转到区块浏览器查看交易记录

### 入口
- 在钱包卡片轮播右上角添加 ⋮ 菜单按钮
- 菜单包含「地址余额查询」和「地址交易查询」两个选项

### 技术实现
- `useAddressBalanceQuery` hook 使用 TanStack Query 封装余额查询
- 复用现有 chain-adapter 服务获取余额
- 交易记录通过区块浏览器链接查看（ETHscan/BSCscan/Tronscan等）

### i18n
- 添加 zh-CN 和 en 翻译

## 截图

功能用于内部诊断工具，无需截图。

## 测试

- [x] lint 通过
- [x] typecheck 通过
- [x] 所有单元测试通过