### PR TITLE
feat(chain-adapter): ordered apis[] fallback + walletapi providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,12 @@
 # 复制此文件为 .env.local 并填入真实值
 # .env.local 文件不会被提交到 git
 
+# ==================== API Keys ====================
+
+# TronGrid API Key（用于高频率 Tron 请求）
+# 申请地址: https://www.trongrid.io/
+# VITE_TRONGRID_API_KEY=""
+
 # ==================== E2E 测试 ====================
 
 # 资金账号助记词 - 用于提供测试资金（24个中文词，空格分隔）

--- a/docs/white-book/附录/I-外部服务提供商/index.md
+++ b/docs/white-book/附录/I-外部服务提供商/index.md
@@ -12,6 +12,26 @@
 
 ---
 
+## KeyApp 配置与 Provider（重要）
+
+KeyApp 的链配置（`public/configs/*.json`）使用有序数组 `apis[]` 描述外部 Provider。
+
+- 字段：`{ type, endpoint, config? }`
+- 顺序：**从前到后**为优先级，前一个失败会自动 fallback 到下一个
+- 破坏性变更：历史的 `api`（对象/字典）已废弃，统一使用 `apis[]`
+
+常见 Provider 类型（示例）：
+
+- EVM：`blockscout-v1` / `*-rpc` / `ethwallet-v1` / `bscwallet-v1`
+- Tron：`tron-rpc` / `tron-rpc-pro` / `tronwallet-v1`
+- Bitcoin：`mempool-v1` / `btcwallet-v1`
+
+TronGrid Key：
+
+- `tron-rpc-pro` 支持在 `config.apiKeyEnv` 指定环境变量（如 `VITE_TRONGRID_API_KEY`），用于注入请求头 `TRON-PRO-API-KEY`
+
+---
+
 ## 链类型分类
 
 | 类型 | 链 | API 路径前缀 | 特点 |
@@ -112,6 +132,11 @@ src/apis/
 | POST | `/wallet/eth/account/balance/v2` | 批量查余额 |
 | GET | `/wallet/eth/getChainId` | 获取 chainId |
 
+KeyApp Provider 对应关系：
+
+- `ethwallet-v1` 以 `/wallet/eth/*` 为前缀
+- `bscwallet-v1` 以 `/wallet/bsc/*` 为前缀
+
 ---
 
 ## 三、比特币 (bitcoin)
@@ -136,6 +161,10 @@ src/apis/
 | GET | `/wallet/btc/blockbook` + `/api/v2/estimatefee/{blocks}` | 费率估算 |
 
 **注意**: Bitcoin API 使用代理模式，通过 POST 发送 `{ url, method }` 参数。
+
+KeyApp Provider 对应关系：
+
+- `btcwallet-v1` 对应 `/wallet/btc/blockbook`（代理 blockbook）
 
 ---
 
@@ -169,6 +198,10 @@ src/apis/
 | POST | `/wallet/tron/contract/tokens` | 代币列表 |
 | POST | `/wallet/tron/contract/token/detail` | 代币详情 |
 | POST | `/wallet/tron/account/balance/v2` | 批量查余额 |
+
+KeyApp Provider 对应关系：
+
+- `tronwallet-v1` 以 `/wallet/tron/*` 为前缀
 
 ---
 

--- a/public/configs/default-chains.json
+++ b/public/configs/default-chains.json
@@ -15,9 +15,7 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "api": {
-        "biowallet-v1": ["https://walletapi.bfmeta.info", { "path": "bfm" }]
-      },
+      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info", "config": { "path": "bfm" } }],
       "explorer": {
         "url": "https://tracker.bfmeta.org",
         "queryTx": "https://tracker.bfmeta.org/#/info/event-details/:signature",
@@ -39,9 +37,7 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "api": {
-        "biowallet-v1": ["https://walletapi.bfmeta.info", { "path": "ccchain" }]
-      }
+      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info", "config": { "path": "ccchain" } }]
     },
     {
       "id": "pmchain",
@@ -57,9 +53,7 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "api": {
-        "biowallet-v1": ["https://walletapi.bfmeta.info", { "path": "pmchain" }]
-      }
+      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info", "config": { "path": "pmchain" } }]
     },
     {
       "id": "bfchainv2",
@@ -75,9 +69,9 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "api": {
-        "biowallet-v1": ["https://walletapi.bfmeta.info", { "path": "bfchainv2" }]
-      }
+      "apis": [
+        { "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info", "config": { "path": "bfchainv2" } }
+      ]
     },
     {
       "id": "btgmeta",
@@ -93,9 +87,7 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "api": {
-        "biowallet-v1": ["https://walletapi.bfmeta.info", { "path": "btgmeta" }]
-      }
+      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info", "config": { "path": "btgmeta" } }]
     },
     {
       "id": "biwmeta",
@@ -109,9 +101,9 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "api": {
-        "biowallet-v1": ["https://walletapi.biw-meta.com", { "path": "biwmeta" }]
-      },
+      "apis": [
+        { "type": "biowallet-v1", "endpoint": "https://walletapi.biw-meta.com", "config": { "path": "biwmeta" } }
+      ],
       "explorer": {
         "url": "https://tracker.biw-meta.info",
         "queryTx": "https://tracker.biw-meta.info/#/info/event-details/:signature",
@@ -133,9 +125,7 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "api": {
-        "biowallet-v1": ["https://walletapi.bfmeta.info", { "path": "ethmeta" }]
-      }
+      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info", "config": { "path": "ethmeta" } }]
     },
     {
       "id": "ethereum",
@@ -150,10 +140,11 @@
         "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/eth"
       ],
       "decimals": 18,
-      "api": {
-        "ethereum-rpc": "https://ethereum-rpc.publicnode.com",
-        "blockscout-v1": "https://eth.blockscout.com/api"
-      },
+      "apis": [
+        { "type": "blockscout-v1", "endpoint": "https://eth.blockscout.com/api" },
+        { "type": "ethereum-rpc", "endpoint": "https://ethereum-rpc.publicnode.com" },
+        { "type": "ethwallet-v1", "endpoint": "https://walletapi.bfmeta.info/wallet/eth" }
+      ],
       "explorer": {
         "url": "https://eth.blockscout.com",
         "queryTx": "https://eth.blockscout.com/tx/:hash",
@@ -173,10 +164,10 @@
         "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/bsc"
       ],
       "decimals": 18,
-      "api": {
-        "bsc-rpc": "https://bsc-rpc.publicnode.com",
-        "bscwallet-v1": "https://walletapi.bfmeta.info/wallet/bsc"
-      },
+      "apis": [
+        { "type": "bsc-rpc", "endpoint": "https://bsc-rpc.publicnode.com" },
+        { "type": "bscwallet-v1", "endpoint": "https://walletapi.bfmeta.info/wallet/bsc" }
+      ],
       "explorer": {
         "url": "https://bscscan.com",
         "queryTx": "https://bscscan.com/tx/:hash",
@@ -196,9 +187,15 @@
         "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/tron"
       ],
       "decimals": 6,
-      "api": {
-        "tron-rpc": "https://api.trongrid.io"
-      },
+      "apis": [
+        { "type": "tron-rpc", "endpoint": "https://api.trongrid.io" },
+        {
+          "type": "tron-rpc-pro",
+          "endpoint": "https://api.trongrid.io",
+          "config": { "apiKeyEnv": "VITE_TRONGRID_API_KEY" }
+        },
+        { "type": "tronwallet-v1", "endpoint": "https://walletapi.bfmeta.info/wallet/tron" }
+      ],
       "explorer": {
         "url": "https://tronscan.org",
         "queryTx": "https://tronscan.org/#/transaction/:hash",
@@ -218,9 +215,10 @@
         "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/btcm"
       ],
       "decimals": 8,
-      "api": {
-        "mempool-v1": "https://mempool.space/api"
-      },
+      "apis": [
+        { "type": "mempool-v1", "endpoint": "https://mempool.space/api" },
+        { "type": "btcwallet-v1", "endpoint": "https://walletapi.bfmeta.info/wallet/btc/blockbook" }
+      ],
       "explorer": {
         "url": "https://mempool.space",
         "queryTx": "https://mempool.space/tx/:hash",

--- a/public/configs/testnet-chains.json
+++ b/public/configs/testnet-chains.json
@@ -9,9 +9,9 @@
       "symbol": "SepoliaETH",
       "icon": "../icons/ethereum/chain.svg",
       "decimals": 18,
-      "api": {
-        "ethereum-rpc": "https://rpc.sepolia.org"
-      },
+      "apis": [
+        { "type": "ethereum-rpc", "endpoint": "https://rpc.sepolia.org" }
+      ],
       "explorer": {
         "url": "https://sepolia.etherscan.io",
         "queryTx": "https://sepolia.etherscan.io/tx/:hash",
@@ -26,9 +26,9 @@
       "symbol": "tBNB",
       "icon": "../icons/binance/chain.svg",
       "decimals": 18,
-      "api": {
-        "ethereum-rpc": "https://bsc-testnet-rpc.publicnode.com"
-      },
+      "apis": [
+        { "type": "ethereum-rpc", "endpoint": "https://bsc-testnet-rpc.publicnode.com" }
+      ],
       "explorer": {
         "url": "https://testnet.bscscan.com",
         "queryTx": "https://testnet.bscscan.com/tx/:hash",
@@ -43,9 +43,9 @@
       "symbol": "TRX",
       "icon": "../icons/tron/chain.svg",
       "decimals": 6,
-      "api": {
-        "tron-rpc": "https://nile.trongrid.io"
-      },
+      "apis": [
+        { "type": "tron-rpc", "endpoint": "https://nile.trongrid.io" }
+      ],
       "explorer": {
         "url": "https://nile.tronscan.org",
         "queryTx": "https://nile.tronscan.org/#/transaction/:hash",
@@ -60,9 +60,9 @@
       "symbol": "sBTC",
       "icon": "../icons/bitcoin/chain.svg",
       "decimals": 8,
-      "api": {
-        "mempool-v1": "https://mempool.space/signet/api"
-      },
+      "apis": [
+        { "type": "mempool-v1", "endpoint": "https://mempool.space/signet/api" }
+      ],
       "explorer": {
         "url": "https://mempool.space/signet",
         "queryTx": "https://mempool.space/signet/tx/:hash",

--- a/scripts/set-secret.ts
+++ b/scripts/set-secret.ts
@@ -112,6 +112,21 @@ const SECRET_DEFINITIONS: SecretDefinition[] = [
     required: true,
     isPassword: true,
   },
+
+  // API Keys
+  {
+    key: 'VITE_TRONGRID_API_KEY',
+    description: 'TronGrid API Key（用于高频率 Tron 请求）',
+    category: 'api-keys',
+    required: false,
+    isPassword: true,
+    validate: (v) => {
+      if (v && !/^[a-f0-9-]{36}$/i.test(v)) {
+        return 'API Key 格式无效（应为 UUID）'
+      }
+      return true
+    },
+  },
 ]
 
 interface CategoryDefinition {
@@ -135,6 +150,11 @@ const CATEGORIES: CategoryDefinition[] = [
     id: 'dweb-dev',
     name: 'DWEB 开发版发布',
     description: 'SFTP 开发服务器账号（用于日常 CI/CD）',
+  },
+  {
+    id: 'api-keys',
+    name: 'API Keys',
+    description: '第三方 API 密钥（TronGrid 等）',
   },
 ]
 

--- a/src/components/wallet/wallet-address-portfolio.real.test.ts
+++ b/src/components/wallet/wallet-address-portfolio.real.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { clearProviderCache, createChainProvider } from "@/services/chain-adapter"
+import type { ChainConfig } from "@/services/chain-config"
+
+const mockGetChainById = vi.fn<(id: string) => ChainConfig | null>()
+
+vi.mock("@/stores/chain-config", () => ({
+  chainConfigStore: {
+    state: {},
+  },
+  chainConfigSelectors: {
+    getChainById: (_state: unknown, id: string) => mockGetChainById(id),
+  },
+}))
+
+async function firstSuccess<T>(options: {
+  chainId: string
+  method: "getNativeBalance" | "getTransactionHistory"
+  args: unknown[]
+}): Promise<{ providerType: string; result: T }> {
+  const provider = createChainProvider(options.chainId)
+  const providers = provider.getProviders()
+
+  let lastError: unknown = null
+
+  for (const candidate of providers) {
+    const fn = (candidate as any)[options.method]
+    if (typeof fn !== "function") continue
+
+    try {
+      const result = (await fn.apply(candidate, options.args)) as T
+      return { providerType: candidate.type, result }
+    } catch (error) {
+      lastError = error
+    }
+  }
+
+  throw new Error(
+    `All providers failed for ${options.chainId}:${options.method}: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+  )
+}
+
+describe.skipIf(!process.env.TEST_REAL_API)("WalletAddressPortfolio Real Provider Sanity", () => {
+  const configs: Record<string, ChainConfig> = {
+    ethereum: {
+      id: "ethereum",
+      version: "1.0",
+      chainKind: "evm",
+      name: "Ethereum",
+      symbol: "ETH",
+      decimals: 18,
+      enabled: true,
+      source: "default",
+      apis: [
+        { type: "blockscout-v1", endpoint: "https://eth.blockscout.com/api" },
+        { type: "ethereum-rpc", endpoint: "https://ethereum-rpc.publicnode.com" },
+        { type: "ethwallet-v1", endpoint: "https://walletapi.bfmeta.info/wallet/eth" },
+      ],
+    },
+    tron: {
+      id: "tron",
+      version: "1.0",
+      chainKind: "tron",
+      name: "Tron",
+      symbol: "TRX",
+      decimals: 6,
+      enabled: true,
+      source: "default",
+      apis: [
+        { type: "tron-rpc", endpoint: "https://api.trongrid.io" },
+        { type: "tron-rpc-pro", endpoint: "https://api.trongrid.io", config: { apiKeyEnv: "VITE_TRONGRID_API_KEY" } },
+        { type: "tronwallet-v1", endpoint: "https://walletapi.bfmeta.info/wallet/tron" },
+      ],
+    },
+    bitcoin: {
+      id: "bitcoin",
+      version: "1.0",
+      chainKind: "bitcoin",
+      name: "Bitcoin",
+      symbol: "BTC",
+      decimals: 8,
+      enabled: true,
+      source: "default",
+      apis: [
+        { type: "mempool-v1", endpoint: "https://mempool.space/api" },
+        { type: "btcwallet-v1", endpoint: "https://walletapi.bfmeta.info/wallet/btc/blockbook" },
+      ],
+    },
+  }
+
+  beforeEach(() => {
+    clearProviderCache()
+    mockGetChainById.mockImplementation((id) => configs[id] ?? null)
+  })
+
+  it(
+    "ethereum should return balance>0 and txs>0",
+    async () => {
+      const address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+
+      const balance = await firstSuccess<{ amount: { raw: bigint } }>({
+        chainId: "ethereum",
+        method: "getNativeBalance",
+        args: [address],
+      })
+      expect(balance.result.amount.raw).toBeGreaterThan(0n)
+      console.log(`[real] ethereum balance provider: ${balance.providerType}`)
+
+      const history = await firstSuccess<unknown[]>({
+        chainId: "ethereum",
+        method: "getTransactionHistory",
+        args: [address, 10],
+      })
+      expect(history.result.length).toBeGreaterThan(0)
+      console.log(`[real] ethereum txHistory provider: ${history.providerType}`)
+    },
+    30_000,
+  )
+
+  it(
+    "tron should return balance>0 and txs>0",
+    async () => {
+      const address = "TN3W4H6rK2ce4vX9YnFQHwKENnHjoxb3m9"
+
+      const balance = await firstSuccess<{ amount: { raw: bigint } }>({
+        chainId: "tron",
+        method: "getNativeBalance",
+        args: [address],
+      })
+      expect(balance.result.amount.raw).toBeGreaterThan(0n)
+      console.log(`[real] tron balance provider: ${balance.providerType}`)
+
+      const history = await firstSuccess<unknown[]>({
+        chainId: "tron",
+        method: "getTransactionHistory",
+        args: [address, 10],
+      })
+      expect(history.result.length).toBeGreaterThan(0)
+      console.log(`[real] tron txHistory provider: ${history.providerType}`)
+    },
+    30_000,
+  )
+
+  it(
+    "bitcoin should return balance>0 and txs>0",
+    async () => {
+      const address = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"
+
+      const balance = await firstSuccess<{ amount: { raw: bigint } }>({
+        chainId: "bitcoin",
+        method: "getNativeBalance",
+        args: [address],
+      })
+      expect(balance.result.amount.raw).toBeGreaterThan(0n)
+      console.log(`[real] bitcoin balance provider: ${balance.providerType}`)
+
+      const history = await firstSuccess<unknown[]>({
+        chainId: "bitcoin",
+        method: "getTransactionHistory",
+        args: [address, 10],
+      })
+      expect(history.result.length).toBeGreaterThan(0)
+      console.log(`[real] bitcoin txHistory provider: ${history.providerType}`)
+    },
+    30_000,
+  )
+})

--- a/src/hooks/use-security-password.ts
+++ b/src/hooks/use-security-password.ts
@@ -95,8 +95,9 @@ export function useSecurityPassword({
   const refresh = useCallback(async () => {
     if (!chainConfig || !address) return
 
-    const apiUrl = chainConfig.api?.url
-    const apiPath = chainConfig.api?.path ?? chainConfig.id
+    const biowallet = chainConfig.apis.find((p) => p.type === 'biowallet-v1')
+    const apiUrl = biowallet?.endpoint
+    const apiPath = (biowallet?.config?.path as string | undefined) ?? chainConfig.id
     if (!apiUrl) {
       securityPasswordActions.setError(address, 'API URL 未配置')
       return

--- a/src/hooks/use-send.bioforest.ts
+++ b/src/hooks/use-send.bioforest.ts
@@ -17,6 +17,13 @@ export interface BioforestFeeResult {
   symbol: string
 }
 
+function getBioforestApi(chainConfig: ChainConfig): { apiUrl: string | null; apiPath: string } {
+  const biowallet = chainConfig.apis.find((p) => p.type === 'biowallet-v1')
+  const apiUrl = biowallet?.endpoint ?? null
+  const apiPath = (biowallet?.config?.path as string | undefined) ?? chainConfig.id
+  return { apiUrl, apiPath }
+}
+
 export async function fetchBioforestFee(chainConfig: ChainConfig, fromAddress: string): Promise<BioforestFeeResult> {
   const adapter = createBioforestAdapter(chainConfig)
   const feeEstimate = await adapter.transaction.estimateFee({
@@ -67,8 +74,7 @@ export async function checkTwoStepSecretRequired(
   chainConfig: ChainConfig,
   address: string,
 ): Promise<{ required: boolean; secondPublicKey?: string }> {
-  const apiUrl = chainConfig.api?.url
-  const apiPath = chainConfig.api?.path ?? chainConfig.id
+  const { apiUrl, apiPath } = getBioforestApi(chainConfig)
   if (!apiUrl) {
     return { required: false }
   }
@@ -131,8 +137,7 @@ export async function submitBioforestTransfer({
     return { status: 'error', message: '请输入有效金额' }
   }
 
-  const apiUrl = chainConfig.api?.url
-  const apiPath = chainConfig.api?.path ?? chainConfig.id
+  const { apiUrl, apiPath } = getBioforestApi(chainConfig)
   if (!apiUrl) {
     return { status: 'error', message: 'API URL 未配置' }
   }
@@ -245,8 +250,7 @@ export async function submitSetTwoStepSecret({
     }
   }
 
-  const apiUrl = chainConfig.api?.url
-  const apiPath = chainConfig.api?.path ?? chainConfig.id
+  const { apiUrl, apiPath } = getBioforestApi(chainConfig)
   if (!apiUrl) {
     return { status: 'error', message: 'API URL 未配置' }
   }
@@ -292,8 +296,7 @@ export async function submitSetTwoStepSecret({
 export async function getSetTwoStepSecretFee(
   chainConfig: ChainConfig,
 ): Promise<{ amount: Amount; symbol: string } | null> {
-  const apiUrl = chainConfig.api?.url
-  const apiPath = chainConfig.api?.path ?? chainConfig.id
+  const { apiUrl, apiPath } = getBioforestApi(chainConfig)
   if (!apiUrl) {
     return null
   }
@@ -317,8 +320,7 @@ export async function hasTwoStepSecretSet(
   chainConfig: ChainConfig,
   address: string,
 ): Promise<boolean> {
-  const apiUrl = chainConfig.api?.url
-  const apiPath = chainConfig.api?.path ?? chainConfig.id
+  const { apiUrl, apiPath } = getBioforestApi(chainConfig)
   if (!apiUrl) {
     return false
   }

--- a/src/lib/crypto/bioforest.test.ts
+++ b/src/lib/crypto/bioforest.test.ts
@@ -311,7 +311,7 @@ describe('BioForest Crypto', () => {
         name: 'Ethereum',
         symbol: 'ETH',
         decimals: 18,
-        api: { url: 'https://example.invalid', path: 'eth' },
+        apis: [{ type: 'ethereum-rpc', endpoint: 'https://example.invalid' }],
         enabled: true,
         source: 'default',
       }

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -149,8 +149,9 @@ export function SettingsPage() {
       // checkConfirmed callback - 检查交易是否上链
       async () => {
         const { getAddressInfo } = await import('@/services/bioforest-sdk');
-        const apiUrl = chainConfig.api?.url;
-        const apiPath = chainConfig.api?.path ?? chainConfig.id;
+        const biowallet = chainConfig.apis.find((p) => p.type === 'biowallet-v1');
+        const apiUrl = biowallet?.endpoint;
+        const apiPath = (biowallet?.config?.path as string | undefined) ?? chainConfig.id;
         if (!apiUrl) return false;
         try {
           const info = await getAddressInfo(apiUrl, apiPath, bfmAddress.address);

--- a/src/queries/use-security-password-query.ts
+++ b/src/queries/use-security-password-query.ts
@@ -49,8 +49,9 @@ export function useSecurityPasswordQuery(
         return { address, secondPublicKey: null }
       }
 
-      const apiUrl = chainConfig.api?.url
-      const apiPath = chainConfig.api?.path ?? chainConfig.id
+      const biowallet = chainConfig.apis.find((p) => p.type === 'biowallet-v1')
+      const apiUrl = biowallet?.endpoint
+      const apiPath = (biowallet?.config?.path as string | undefined) ?? chainConfig.id
       
       if (!apiUrl) {
         console.warn(`[useSecurityPasswordQuery] API URL not configured for ${chain}`)

--- a/src/services/chain-adapter/__tests__/bioforest-api.test.ts
+++ b/src/services/chain-adapter/__tests__/bioforest-api.test.ts
@@ -19,7 +19,7 @@ const mockConfigWithRpc: ChainConfig = {
   decimals: 8,
   enabled: true,
   source: 'default',
-  api: { url: 'https://walletapi.bfmeta.info', path: 'bfm' },
+  apis: [{ type: 'biowallet-v1', endpoint: 'https://walletapi.bfmeta.info', config: { path: 'bfm' } }],
 }
 
 // Mock chainConfigService

--- a/src/services/chain-adapter/bioforest/asset-service.test.ts
+++ b/src/services/chain-adapter/bioforest/asset-service.test.ts
@@ -13,14 +13,12 @@ vi.mock('@/services/chain-config', () => ({
       if (chainId === 'bfmeta') {
         return {
           id: 'bfmeta',
+          version: '1.0',
           chainKind: 'bioforest',
           name: 'BFMeta',
           symbol: 'BFM',
           decimals: 8,
-          api: {
-            url: 'https://walletapi.bfmeta.info',
-            path: 'bfm',
-          },
+          apis: [{ type: 'biowallet-v1', endpoint: 'https://walletapi.bfmeta.info', config: { path: 'bfm' } }],
         }
       }
       return null

--- a/src/services/chain-adapter/providers/__tests__/biowallet-provider.biwmeta.real.test.ts
+++ b/src/services/chain-adapter/providers/__tests__/biowallet-provider.biwmeta.real.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -13,7 +13,12 @@ vi.mock('@/services/chain-config', () => ({
 }));
 
 const mockFetch = vi.fn();
+const originalFetch = global.fetch;
 global.fetch = mockFetch;
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
 
 function readFixture<T>(name: string): T {
   const dir = path.dirname(fileURLToPath(import.meta.url));

--- a/src/services/chain-adapter/providers/__tests__/biowallet-provider.real.test.ts
+++ b/src/services/chain-adapter/providers/__tests__/biowallet-provider.real.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -13,7 +13,12 @@ vi.mock('@/services/chain-config', () => ({
 }))
 
 const mockFetch = vi.fn()
+const originalFetch = global.fetch
 global.fetch = mockFetch
+
+afterAll(() => {
+  global.fetch = originalFetch
+})
 
 function readFixture<T>(name: string): T {
   const dir = path.dirname(fileURLToPath(import.meta.url))

--- a/src/services/chain-adapter/providers/__tests__/btcwallet-provider.test.ts
+++ b/src/services/chain-adapter/providers/__tests__/btcwallet-provider.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+import { BtcWalletProvider, createBtcwalletProvider } from '../btcwallet-provider'
+import type { ParsedApiEntry } from '@/services/chain-config'
+
+vi.mock('@/services/chain-config', () => ({
+  chainConfigService: {
+    getSymbol: () => 'BTC',
+    getDecimals: () => 8,
+  },
+}))
+
+const mockFetch = vi.fn()
+const originalFetch = global.fetch
+global.fetch = mockFetch
+
+afterAll(() => {
+  global.fetch = originalFetch
+})
+
+describe('BtcWalletProvider', () => {
+  const entry: ParsedApiEntry = {
+    type: 'btcwallet-v1',
+    endpoint: 'https://walletapi.example.com/wallet/btc/blockbook',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('createBtcwalletProvider creates provider for btcwallet-v1', () => {
+    const provider = createBtcwalletProvider(entry, 'bitcoin')
+    expect(provider).toBeInstanceOf(BtcWalletProvider)
+  })
+
+  it('maps balance (confirmed + unconfirmed) to Amount', async () => {
+    const address = 'bc1qexample'
+
+    mockFetch.mockImplementation(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? '{}'))
+      expect(body.method).toBe('GET')
+      expect(body.url).toContain(`/api/v2/address/${address}`)
+      return { ok: true, json: async () => ({ balance: '10', unconfirmedBalance: '-2' }) }
+    })
+
+    const provider = new BtcWalletProvider(entry, 'bitcoin')
+    const balance = await provider.getNativeBalance(address)
+    expect(balance.amount.raw).toBe(8n)
+  })
+
+  it('computes direction and value from vin/vout', async () => {
+    const address = 'bc1qme'
+
+    mockFetch.mockImplementation(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body ?? '{}'))
+      if (String(body.url).includes('details=txs')) {
+        return {
+          ok: true,
+          json: async () => ({
+            balance: '0',
+            transactions: [
+              {
+                txid: 'tx1',
+                blockHeight: 100,
+                confirmations: 1,
+                blockTime: 1700000000,
+                vin: [{ addresses: [address], value: '5000' }],
+                vout: [{ addresses: ['bc1qother'], value: '3000' }, { addresses: [address], value: '1900' }],
+              },
+            ],
+          }),
+        }
+      }
+      return { ok: true, json: async () => ({ balance: '0' }) }
+    })
+
+    const provider = new BtcWalletProvider(entry, 'bitcoin')
+    const txs = await provider.getTransactionHistory(address, 10)
+
+    expect(txs).toHaveLength(1)
+    expect(txs[0].direction).toBe('out')
+    expect(txs[0].assets[0]).toMatchObject({
+      assetType: 'native',
+      symbol: 'BTC',
+      decimals: 8,
+      value: '3100',
+    })
+  })
+})

--- a/src/services/chain-adapter/providers/__tests__/etherscan-provider.test.ts
+++ b/src/services/chain-adapter/providers/__tests__/etherscan-provider.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { EtherscanProvider, createEtherscanProvider } from '../etherscan-provider'
+import { resetFetchJsonForTests } from '../fetch-json'
 import type { ParsedApiEntry } from '@/services/chain-config'
 
 // Mock chainConfigService
@@ -15,7 +16,12 @@ vi.mock('@/services/chain-config', () => ({
 
 // Mock fetch
 const mockFetch = vi.fn()
+const originalFetch = global.fetch
 global.fetch = mockFetch
+
+afterAll(() => {
+  global.fetch = originalFetch
+})
 
 function readFixture<T>(name: string): T {
   const dir = path.dirname(fileURLToPath(import.meta.url))
@@ -31,6 +37,7 @@ describe('EtherscanProvider', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    resetFetchJsonForTests()
   })
 
   describe('createEtherscanProvider', () => {

--- a/src/services/chain-adapter/providers/__tests__/ethwallet-provider.test.ts
+++ b/src/services/chain-adapter/providers/__tests__/ethwallet-provider.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+import { EthWalletProvider, createEthwalletProvider } from '../ethwallet-provider'
+import type { ParsedApiEntry } from '@/services/chain-config'
+
+vi.mock('@/services/chain-config', () => ({
+  chainConfigService: {
+    getSymbol: () => 'ETH',
+    getDecimals: () => 18,
+  },
+}))
+
+const mockFetch = vi.fn()
+const originalFetch = global.fetch
+global.fetch = mockFetch
+
+afterAll(() => {
+  global.fetch = originalFetch
+})
+
+describe('EthWalletProvider', () => {
+  const entry: ParsedApiEntry = {
+    type: 'ethwallet-v1',
+    endpoint: 'https://walletapi.example.com/wallet/eth',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('createEthwalletProvider creates provider for ethwallet-v1', () => {
+    const provider = createEthwalletProvider(entry, 'ethereum')
+    expect(provider).toBeInstanceOf(EthWalletProvider)
+  })
+
+  it('maps balance string to Amount', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => '1000000000000000000' })
+
+    const provider = new EthWalletProvider(entry, 'ethereum')
+    const balance = await provider.getNativeBalance('0xabc')
+
+    expect(balance.symbol).toBe('ETH')
+    expect(balance.amount.raw).toBe(1000000000000000000n)
+  })
+
+  it('aggregates normal + erc20 history by hash and prioritizes token asset', async () => {
+    const user = '0x75a6F48BF634868b2980c97CcEf467A127597e08'
+    const hash = '0xabc123'
+
+    const nativeTx = {
+      hash,
+      from: user,
+      to: '0xContract',
+      value: '0',
+      timeStamp: '1700000000',
+      isError: '0',
+      blockNumber: '123',
+      methodId: '0xa9059cbb',
+      functionName: 'transfer(address,uint256)',
+    }
+    const tokenTx = {
+      hash,
+      from: user,
+      to: '0xReceiver',
+      value: '3000000',
+      timeStamp: '1700000000',
+      blockNumber: '123',
+      tokenSymbol: 'USDT',
+      tokenName: 'Tether USD',
+      tokenDecimal: '6',
+      contractAddress: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+    }
+
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/trans/normal/history')) {
+        expect(init?.method).toBe('POST')
+        return { ok: true, json: async () => ({ status: '1', result: [nativeTx] }) }
+      }
+      if (url.endsWith('/trans/erc20/history')) {
+        expect(init?.method).toBe('POST')
+        return { ok: true, json: async () => ({ status: '1', result: [tokenTx] }) }
+      }
+      return { ok: true, json: async () => ({ status: '1', result: [] }) }
+    })
+
+    const provider = new EthWalletProvider(entry, 'ethereum')
+    const txs = await provider.getTransactionHistory(user, 10)
+
+    expect(txs).toHaveLength(1)
+    expect(txs[0].hash).toBe(hash)
+    expect(txs[0].assets[0]).toMatchObject({
+      assetType: 'token',
+      symbol: 'USDT',
+      decimals: 6,
+      contractAddress: tokenTx.contractAddress,
+      value: tokenTx.value,
+    })
+  })
+})

--- a/src/services/chain-adapter/providers/__tests__/integration.test.ts
+++ b/src/services/chain-adapter/providers/__tests__/integration.test.ts
@@ -35,10 +35,10 @@ describe('ChainProvider 集成测试', () => {
       decimals: 18,
       enabled: true,
       source: 'default',
-      api: {
-        'ethereum-rpc': 'https://ethereum-rpc.publicnode.com',
-        'etherscan-v2': 'https://api.etherscan.io/v2/api',
-      },
+      apis: [
+        { type: 'etherscan-v2', endpoint: 'https://api.etherscan.io/v2/api' },
+        { type: 'ethereum-rpc', endpoint: 'https://ethereum-rpc.publicnode.com' },
+      ],
     }
     mockGetChainById.mockReturnValue(mockEthConfig)
 
@@ -72,9 +72,7 @@ describe('ChainProvider 集成测试', () => {
       prefix: 'b',
       enabled: true,
       source: 'default',
-      api: {
-        'biowallet-v1': ['https://walletapi.bfmeta.info', { path: 'bfmeta' }],
-      },
+      apis: [{ type: 'biowallet-v1', endpoint: 'https://walletapi.bfmeta.info', config: { path: 'bfmeta' } }],
     }
     mockGetChainById.mockReturnValue(mockBfmetaConfig)
 
@@ -112,9 +110,7 @@ describe('ChainProvider 集成测试', () => {
       decimals: 18,
       enabled: true,
       source: 'default',
-      api: {
-        'ethereum-rpc': 'https://rpc.test.com',
-      },
+      apis: [{ type: 'ethereum-rpc', endpoint: 'https://rpc.test.com' }],
     }
     mockGetChainById.mockReturnValue(mockConfig)
 

--- a/src/services/chain-adapter/providers/__tests__/tronwallet-provider.test.ts
+++ b/src/services/chain-adapter/providers/__tests__/tronwallet-provider.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
+import { TronWalletProvider, createTronwalletProvider } from '../tronwallet-provider'
+import type { ParsedApiEntry } from '@/services/chain-config'
+
+vi.mock('@/services/chain-config', () => ({
+  chainConfigService: {
+    getSymbol: () => 'TRX',
+    getDecimals: () => 6,
+  },
+}))
+
+const mockFetch = vi.fn()
+const originalFetch = global.fetch
+global.fetch = mockFetch
+
+afterAll(() => {
+  global.fetch = originalFetch
+})
+
+/** Base58 alphabet used by Tron */
+const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+function decodeBase58(str: string): Uint8Array {
+  let num = BigInt(0)
+  for (const char of str) {
+    const index = ALPHABET.indexOf(char)
+    if (index === -1) throw new Error('Invalid base58')
+    num = num * 58n + BigInt(index)
+  }
+
+  const hex = num.toString(16).padStart(50, '0')
+  const bytes = new Uint8Array(25)
+  for (let i = 0; i < 25; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+function tronBase58ToHex(address: string): string {
+  const payload = decodeBase58(address).slice(0, 21)
+  return Array.from(payload).map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+describe('TronWalletProvider', () => {
+  const entry: ParsedApiEntry = {
+    type: 'tronwallet-v1',
+    endpoint: 'https://walletapi.example.com/wallet/tron',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('createTronwalletProvider creates provider for tronwallet-v1', () => {
+    const provider = createTronwalletProvider(entry, 'tron')
+    expect(provider).toBeInstanceOf(TronWalletProvider)
+  })
+
+  it('converts base58 address to hex for balance query', async () => {
+    const address = 'TZ4UXDV5ZhNW7fb2AMSbgfAEZ7hWsnYS2g'
+    const expectedHex = tronBase58ToHex(address)
+
+    mockFetch.mockImplementation(async (url: string) => {
+      expect(url).toContain(`/balance?address=${expectedHex}`)
+      return { ok: true, json: async () => '1000000' }
+    })
+
+    const provider = new TronWalletProvider(entry, 'tron')
+    const balance = await provider.getNativeBalance(address)
+    expect(balance.amount.raw).toBe(1000000n)
+  })
+
+  it('maps tx history and converts hex addresses to base58', async () => {
+    const address = 'TZ4UXDV5ZhNW7fb2AMSbgfAEZ7hWsnYS2g'
+    const hexAddress = tronBase58ToHex(address)
+
+    const nativeTx = {
+      contractRet: 'SUCCESS',
+      txID: 'tx1',
+      blockNumber: 10,
+      from: hexAddress,
+      to: hexAddress,
+      amount: 123,
+      timestamp: 1700000000000,
+    }
+
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.endsWith('/trans/common/history')) {
+        return { ok: true, json: async () => ({ success: true, data: [nativeTx] }) }
+      }
+      if (url.endsWith('/trans/trc20/history')) {
+        return { ok: true, json: async () => ({ success: true, data: [] }) }
+      }
+      return { ok: true, json: async () => ({ success: true, data: [] }) }
+    })
+
+    const provider = new TronWalletProvider(entry, 'tron')
+    const txs = await provider.getTransactionHistory(address, 10)
+    expect(txs).toHaveLength(1)
+    expect(txs[0].from).toBe(address)
+    expect(txs[0].to).toBe(address)
+    expect(txs[0].assets[0]).toMatchObject({
+      assetType: 'native',
+      symbol: 'TRX',
+      decimals: 6,
+      value: '123',
+    })
+  })
+})

--- a/src/services/chain-adapter/providers/btcwallet-provider.ts
+++ b/src/services/chain-adapter/providers/btcwallet-provider.ts
@@ -1,0 +1,195 @@
+import { z } from 'zod'
+import type { ApiProvider, Balance, Transaction, Direction } from './types'
+import type { ParsedApiEntry } from '@/services/chain-config'
+import { chainConfigService } from '@/services/chain-config'
+import { Amount } from '@/types/amount'
+import { fetchJson, observeValueAndInvalidate } from './fetch-json'
+
+const BlockbookErrorSchema = z.looseObject({
+  error: z.string(),
+})
+
+const BlockbookVinSchema = z.looseObject({
+  addresses: z.array(z.string()),
+  value: z.string(),
+})
+
+const BlockbookVoutSchema = z.looseObject({
+  addresses: z.array(z.string()),
+  value: z.string(),
+})
+
+const BlockbookTxSchema = z.looseObject({
+  txid: z.string(),
+  blockHeight: z.number(),
+  confirmations: z.number(),
+  blockTime: z.number(),
+  vin: z.array(BlockbookVinSchema),
+  vout: z.array(BlockbookVoutSchema),
+  fees: z.string().optional(),
+})
+
+const BlockbookAddressInfoSchema = z.looseObject({
+  address: z.string().optional(),
+  balance: z.string(),
+  unconfirmedBalance: z.string().optional(),
+  txs: z.number().optional(),
+  transactions: z.array(BlockbookTxSchema).optional(),
+})
+
+function sumValues(items: Array<{ addresses: string[]; value: string }>, address: string): bigint {
+  let sum = 0n
+  for (const item of items) {
+    if (item.addresses.some((a) => a === address)) {
+      sum += BigInt(item.value)
+    }
+  }
+  return sum
+}
+
+function getDirection(net: bigint): Direction {
+  if (net > 0n) return 'in'
+  if (net < 0n) return 'out'
+  return 'self'
+}
+
+export class BtcWalletProvider implements ApiProvider {
+  readonly type: string
+  readonly endpoint: string
+  readonly config?: Record<string, unknown>
+
+  private readonly chainId: string
+  private readonly symbol: string
+  private readonly decimals: number
+
+  constructor(entry: ParsedApiEntry, chainId: string) {
+    this.type = entry.type
+    this.endpoint = entry.endpoint
+    this.config = entry.config
+    this.chainId = chainId
+    this.symbol = chainConfigService.getSymbol(chainId)
+    this.decimals = chainConfigService.getDecimals(chainId)
+  }
+
+  get supportsNativeBalance() {
+    return true
+  }
+
+  get supportsTransactionHistory() {
+    return true
+  }
+
+  async getNativeBalance(address: string): Promise<Balance> {
+    const info = await this.proxyGet(`/api/v2/address/${address}`, BlockbookAddressInfoSchema, {
+      cacheKey: `btcwallet:${this.chainId}:address:${address}`,
+      ttlMs: 60_000,
+      tags: [`balance:${this.chainId}:${address}`],
+    })
+
+    const confirmed = BigInt(info.balance)
+    const unconfirmed = BigInt(info.unconfirmedBalance ?? '0')
+    const total = confirmed + unconfirmed
+
+    observeValueAndInvalidate({
+      key: `balance:${this.chainId}:${address}`,
+      value: total.toString(),
+      invalidateTags: [`txhistory:${this.chainId}:${address}`],
+    })
+
+    return {
+      amount: Amount.fromRaw(total.toString(), this.decimals, this.symbol),
+      symbol: this.symbol,
+    }
+  }
+
+  async getTransactionHistory(address: string, limit = 20): Promise<Transaction[]> {
+    const info = await this.proxyGet(
+      `/api/v2/address/${address}?details=txs&page=1&pageSize=${limit}`,
+      BlockbookAddressInfoSchema,
+      {
+        cacheKey: `btcwallet:${this.chainId}:txs:${address}:${limit}`,
+        ttlMs: 5 * 60_000,
+        tags: [`txhistory:${this.chainId}:${address}`],
+      },
+    )
+
+    const txs = info.transactions ?? []
+    const results: Transaction[] = txs.map((tx) => {
+      const inSum = sumValues(tx.vin, address)
+      const outSum = sumValues(tx.vout, address)
+      const net = outSum - inSum
+      const direction = getDirection(net)
+      const value = net < 0n ? (-net).toString() : net.toString()
+
+      const from = direction === 'in'
+        ? (tx.vin[0]?.addresses?.[0] ?? '')
+        : address
+
+      const toCandidate = tx.vout
+        .flatMap((v) => v.addresses)
+        .find((a) => a !== address)
+      const to = direction === 'out'
+        ? (toCandidate ?? address)
+        : address
+
+      return {
+        hash: tx.txid,
+        from,
+        to,
+        timestamp: tx.blockTime * 1000,
+        status: tx.confirmations > 0 ? 'confirmed' : 'pending',
+        blockNumber: tx.blockHeight > 0 ? BigInt(tx.blockHeight) : undefined,
+        action: 'transfer',
+        direction,
+        assets: [
+          {
+            assetType: 'native' as const,
+            value,
+            symbol: this.symbol,
+            decimals: this.decimals,
+          },
+        ],
+      }
+    })
+
+    return results.sort((a, b) => b.timestamp - a.timestamp)
+  }
+
+  private async proxyGet<T>(
+    path: string,
+    schema: z.ZodType<T>,
+    options?: { cacheKey?: string; ttlMs?: number; tags?: string[] },
+  ): Promise<T> {
+    const json: unknown = await fetchJson(
+      this.endpoint,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: path, method: 'GET' }),
+      },
+      {
+        cacheKey: options?.cacheKey,
+        ttlMs: options?.ttlMs,
+        tags: options?.tags,
+      },
+    )
+
+    const err = BlockbookErrorSchema.safeParse(json)
+    if (err.success && err.data.error) {
+      throw new Error(err.data.error)
+    }
+
+    const parsed = schema.safeParse(json)
+    if (!parsed.success) {
+      throw new Error('Invalid API response')
+    }
+    return parsed.data
+  }
+}
+
+export function createBtcwalletProvider(entry: ParsedApiEntry, chainId: string): ApiProvider | null {
+  if (entry.type === 'btcwallet-v1') {
+    return new BtcWalletProvider(entry, chainId)
+  }
+  return null
+}

--- a/src/services/chain-adapter/providers/ethwallet-provider.ts
+++ b/src/services/chain-adapter/providers/ethwallet-provider.ts
@@ -1,0 +1,284 @@
+import { z } from 'zod'
+import type { ApiProvider, Balance, Transaction, Direction, Action } from './types'
+import type { ParsedApiEntry } from '@/services/chain-config'
+import { chainConfigService } from '@/services/chain-config'
+import { Amount } from '@/types/amount'
+import { fetchJson, observeValueAndInvalidate } from './fetch-json'
+
+const BalanceResponseSchema = z.union([
+  z.string(),
+  z.number().transform((v) => String(v)),
+])
+
+const HistoryResponseSchema = z.looseObject({
+  status: z.string().optional(),
+  result: z.array(z.unknown()),
+})
+
+const NativeTxSchema = z.looseObject({
+  blockNumber: z.string(),
+  timeStamp: z.string(),
+  hash: z.string(),
+  from: z.string(),
+  to: z.string(),
+  value: z.string(),
+  isError: z.string().optional(),
+  input: z.string().optional(),
+  methodId: z.string().optional(),
+  functionName: z.string().optional(),
+})
+
+const TokenTxSchema = z.looseObject({
+  blockNumber: z.string(),
+  timeStamp: z.string(),
+  hash: z.string(),
+  from: z.string(),
+  to: z.string(),
+  value: z.string(),
+  tokenName: z.string(),
+  tokenSymbol: z.string(),
+  tokenDecimal: z.string(),
+  contractAddress: z.string(),
+})
+
+type NativeTx = z.infer<typeof NativeTxSchema>
+type TokenTx = z.infer<typeof TokenTxSchema>
+
+const FETCH_MULTIPLIER = 5
+
+function getDirection(from: string, to: string, normalizedAddress: string): Direction {
+  const fromLower = from.toLowerCase()
+  const toLower = to.toLowerCase()
+
+  if (fromLower === normalizedAddress && toLower === normalizedAddress) return 'self'
+  if (fromLower === normalizedAddress) return 'out'
+  return 'in'
+}
+
+function detectAction(tx: NativeTx): Action {
+  const value = tx.value
+  if (value && value !== '0') return 'transfer'
+  return 'contract'
+}
+
+function selectPrimaryToken(tokenTxs: TokenTx[], normalizedAddress: string): TokenTx | null {
+  if (tokenTxs.length === 0) return null
+  if (tokenTxs.length === 1) return tokenTxs[0]
+
+  const involving = tokenTxs.filter(
+    (t) => t.from.toLowerCase() === normalizedAddress || t.to.toLowerCase() === normalizedAddress,
+  )
+  const candidates = involving.length > 0 ? involving : tokenTxs
+
+  return candidates.reduce((max, t) => {
+    const maxVal = BigInt(max.value)
+    const tVal = BigInt(t.value)
+    return tVal > maxVal ? t : max
+  })
+}
+
+export class EthWalletProvider implements ApiProvider {
+  readonly type: string
+  readonly endpoint: string
+  readonly config?: Record<string, unknown>
+
+  private readonly chainId: string
+  private readonly symbol: string
+  private readonly decimals: number
+
+  constructor(entry: ParsedApiEntry, chainId: string) {
+    this.type = entry.type
+    this.endpoint = entry.endpoint
+    this.config = entry.config
+    this.chainId = chainId
+    this.symbol = chainConfigService.getSymbol(chainId)
+    this.decimals = chainConfigService.getDecimals(chainId)
+  }
+
+  get supportsNativeBalance() {
+    return true
+  }
+
+  get supportsTransactionHistory() {
+    return true
+  }
+
+  async getNativeBalance(address: string): Promise<Balance> {
+    const url = new URL(`${this.endpoint}/balance`)
+    url.searchParams.set('address', address)
+
+    const json: unknown = await fetchJson(url.toString(), undefined, {
+      cacheKey: `ethwallet:${this.chainId}:balance:${address}`,
+      ttlMs: 60_000,
+      tags: [`balance:${this.chainId}:${address}`],
+    })
+    const parsed = BalanceResponseSchema.safeParse(json)
+    if (!parsed.success) {
+      throw new Error('Invalid API response')
+    }
+
+    observeValueAndInvalidate({
+      key: `balance:${this.chainId}:${address}`,
+      value: parsed.data,
+      invalidateTags: [`txhistory:${this.chainId}:${address}`],
+    })
+
+    return {
+      amount: Amount.fromRaw(parsed.data, this.decimals, this.symbol),
+      symbol: this.symbol,
+    }
+  }
+
+  async getTransactionHistory(address: string, limit = 20): Promise<Transaction[]> {
+    const fetchLimit = limit * FETCH_MULTIPLIER
+
+    const [nativeTxs, tokenTxs] = await Promise.all([
+      this.fetchHistory<NativeTx>(`${this.endpoint}/trans/normal/history`, address, fetchLimit, NativeTxSchema, 'normal'),
+      this.fetchHistory<TokenTx>(`${this.endpoint}/trans/erc20/history`, address, fetchLimit, TokenTxSchema, 'erc20'),
+    ])
+
+    const normalizedAddress = address.toLowerCase()
+    const tokenTxsByHash = new Map<string, TokenTx[]>()
+    for (const t of tokenTxs) {
+      const hash = t.hash.toLowerCase()
+      const existing = tokenTxsByHash.get(hash) ?? []
+      existing.push(t)
+      tokenTxsByHash.set(hash, existing)
+    }
+
+    const results: Transaction[] = []
+    const processed = new Set<string>()
+
+    for (const ntx of nativeTxs) {
+      const hash = ntx.hash.toLowerCase()
+      if (processed.has(hash)) continue
+      processed.add(hash)
+
+      const relatedTokens = tokenTxsByHash.get(hash) ?? []
+      const primaryToken = selectPrimaryToken(relatedTokens, normalizedAddress)
+
+      if (primaryToken) {
+        results.push({
+          hash: primaryToken.hash,
+          from: primaryToken.from,
+          to: primaryToken.to,
+          timestamp: Number(primaryToken.timeStamp) * 1000,
+          status: 'confirmed',
+          blockNumber: BigInt(primaryToken.blockNumber),
+          action: 'transfer',
+          direction: getDirection(primaryToken.from, primaryToken.to, normalizedAddress),
+          assets: [
+            {
+              assetType: 'token' as const,
+              value: primaryToken.value,
+              symbol: primaryToken.tokenSymbol,
+              decimals: parseInt(primaryToken.tokenDecimal, 10),
+              contractAddress: primaryToken.contractAddress,
+              name: primaryToken.tokenName,
+            },
+          ],
+          contract: {
+            address: ntx.to,
+            method: ntx.functionName ?? undefined,
+            methodId: ntx.methodId ?? undefined,
+          },
+        })
+        continue
+      }
+
+      results.push({
+        hash: ntx.hash,
+        from: ntx.from,
+        to: ntx.to,
+        timestamp: Number(ntx.timeStamp) * 1000,
+        status: ntx.isError === '1' ? 'failed' : 'confirmed',
+        blockNumber: BigInt(ntx.blockNumber),
+        action: detectAction(ntx),
+        direction: getDirection(ntx.from, ntx.to, normalizedAddress),
+        assets: [
+          {
+            assetType: 'native' as const,
+            value: ntx.value,
+            symbol: this.symbol,
+            decimals: this.decimals,
+          },
+        ],
+        contract: ntx.value === '0' ? {
+          address: ntx.to,
+          method: ntx.functionName ?? undefined,
+          methodId: ntx.methodId ?? undefined,
+        } : undefined,
+      })
+    }
+
+    for (const ttx of tokenTxs) {
+      const hash = ttx.hash.toLowerCase()
+      if (processed.has(hash)) continue
+      processed.add(hash)
+
+      results.push({
+        hash: ttx.hash,
+        from: ttx.from,
+        to: ttx.to,
+        timestamp: Number(ttx.timeStamp) * 1000,
+        status: 'confirmed',
+        blockNumber: BigInt(ttx.blockNumber),
+        action: 'transfer',
+        direction: getDirection(ttx.from, ttx.to, normalizedAddress),
+        assets: [
+          {
+            assetType: 'token' as const,
+            value: ttx.value,
+            symbol: ttx.tokenSymbol,
+            decimals: parseInt(ttx.tokenDecimal, 10),
+            contractAddress: ttx.contractAddress,
+            name: ttx.tokenName,
+          },
+        ],
+      })
+    }
+
+    return results
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .slice(0, limit)
+  }
+
+  private async fetchHistory<T>(
+    url: string,
+    address: string,
+    limit: number,
+    itemSchema: z.ZodType<T>,
+    kind: string,
+  ): Promise<T[]> {
+    const json: unknown = await fetchJson(
+      url,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ address, page: 1, offset: limit }),
+      },
+      {
+        cacheKey: `ethwallet:${this.chainId}:${kind}:${address}:${limit}`,
+        ttlMs: 5 * 60_000,
+        tags: [`txhistory:${this.chainId}:${address}`],
+      },
+    )
+
+    const parsed = HistoryResponseSchema.safeParse(json)
+    if (!parsed.success) {
+      throw new Error('Invalid API response')
+    }
+
+    return parsed.data.result
+      .map((item) => itemSchema.safeParse(item))
+      .filter((r): r is z.SafeParseSuccess<T> => r.success)
+      .map((r) => r.data)
+  }
+}
+
+export function createEthwalletProvider(entry: ParsedApiEntry, chainId: string): ApiProvider | null {
+  if (entry.type === 'ethwallet-v1') {
+    return new EthWalletProvider(entry, chainId)
+  }
+  return null
+}

--- a/src/services/chain-adapter/providers/fetch-json.ts
+++ b/src/services/chain-adapter/providers/fetch-json.ts
@@ -1,0 +1,108 @@
+export type FetchJsonOptions = {
+  /** Cache key; defaults to method+url+body (string bodies only). */
+  cacheKey?: string
+  /** TTL for response JSON cache; 0/undefined disables caching. */
+  ttlMs?: number
+  /** Tags for invalidation; only effective when ttlMs > 0. */
+  tags?: string[]
+}
+
+type CacheEntry = {
+  expiresAt: number
+  value: unknown
+}
+
+const inFlight = new Map<string, Promise<unknown>>()
+const jsonCache = new Map<string, CacheEntry>()
+const tagIndex = new Map<string, Set<string>>()
+
+const observedValues = new Map<string, string>()
+
+function buildDefaultKey(url: string, init?: RequestInit): string {
+  const method = (init?.method ?? 'GET').toUpperCase()
+  const body = typeof init?.body === 'string' ? init.body : ''
+  return `${method}:${url}:${body}`
+}
+
+function addTags(cacheKey: string, tags: string[]): void {
+  for (const tag of tags) {
+    const existing = tagIndex.get(tag) ?? new Set<string>()
+    existing.add(cacheKey)
+    tagIndex.set(tag, existing)
+  }
+}
+
+export function invalidateTags(tags: string[]): void {
+  for (const tag of tags) {
+    const keys = tagIndex.get(tag)
+    if (!keys) continue
+    for (const key of keys) {
+      jsonCache.delete(key)
+    }
+    tagIndex.delete(tag)
+  }
+}
+
+/**
+ * Record a string value and invalidate tags if it changes.
+ * Useful for "balance changed => invalidate tx history" policies.
+ */
+export function observeValueAndInvalidate(options: {
+  key: string
+  value: string
+  invalidateTags: string[]
+}): void {
+  const previous = observedValues.get(options.key)
+  observedValues.set(options.key, options.value)
+
+  if (previous !== undefined && previous !== options.value) {
+    invalidateTags(options.invalidateTags)
+  }
+}
+
+export async function fetchJson<T>(url: string, init?: RequestInit, options?: FetchJsonOptions): Promise<T> {
+  const ttlMs = options?.ttlMs ?? 0
+  const cacheKey = options?.cacheKey ?? buildDefaultKey(url, init)
+
+  if (ttlMs > 0) {
+    const cached = jsonCache.get(cacheKey)
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value as T
+    }
+  }
+
+  const inflight = inFlight.get(cacheKey)
+  if (inflight) {
+    return (await inflight) as T
+  }
+
+  const task = (async () => {
+    const response = await fetch(url, init)
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`)
+    }
+    return (await response.json()) as unknown
+  })()
+
+  inFlight.set(cacheKey, task)
+
+  try {
+    const value = await task
+    if (ttlMs > 0) {
+      jsonCache.set(cacheKey, { value, expiresAt: Date.now() + ttlMs })
+      if (options?.tags?.length) {
+        addTags(cacheKey, options.tags)
+      }
+    }
+    return value as T
+  } finally {
+    inFlight.delete(cacheKey)
+  }
+}
+
+export function resetFetchJsonForTests(): void {
+  inFlight.clear()
+  jsonCache.clear()
+  tagIndex.clear()
+  observedValues.clear()
+}

--- a/src/services/chain-adapter/providers/index.ts
+++ b/src/services/chain-adapter/providers/index.ts
@@ -14,6 +14,9 @@ export { BiowalletProvider, createBiowalletProvider } from './biowallet-provider
 export { BscWalletProvider, createBscWalletProvider } from './bscwallet-provider'
 export { TronRpcProvider, createTronRpcProvider } from './tron-rpc-provider'
 export { MempoolProvider, createMempoolProvider } from './mempool-provider'
+export { EthWalletProvider, createEthwalletProvider } from './ethwallet-provider'
+export { TronWalletProvider, createTronwalletProvider } from './tronwallet-provider'
+export { BtcWalletProvider, createBtcwalletProvider } from './btcwallet-provider'
 
 // Wrapped Provider 实现
 export { WrappedTransactionProvider } from './wrapped-transaction-provider'
@@ -31,6 +34,9 @@ import { createBiowalletProvider } from './biowallet-provider'
 import { createBscWalletProvider } from './bscwallet-provider'
 import { createTronRpcProvider } from './tron-rpc-provider'
 import { createMempoolProvider } from './mempool-provider'
+import { createEthwalletProvider } from './ethwallet-provider'
+import { createTronwalletProvider } from './tronwallet-provider'
+import { createBtcwalletProvider } from './btcwallet-provider'
 import { WrappedTransactionProvider } from './wrapped-transaction-provider'
 import { WrappedIdentityProvider } from './wrapped-identity-provider'
 
@@ -56,6 +62,9 @@ const PROVIDER_FACTORIES: ApiProviderFactory[] = [
   createEvmRpcProvider,
   createTronRpcProvider,
   createMempoolProvider,
+  createEthwalletProvider,
+  createTronwalletProvider,
+  createBtcwalletProvider,
 ]
 
 /**

--- a/src/services/chain-adapter/providers/tronwallet-provider.ts
+++ b/src/services/chain-adapter/providers/tronwallet-provider.ts
@@ -1,0 +1,330 @@
+import { z } from 'zod'
+import type { ApiProvider, Balance, Transaction, Direction } from './types'
+import type { ParsedApiEntry } from '@/services/chain-config'
+import { chainConfigService } from '@/services/chain-config'
+import { Amount } from '@/types/amount'
+import { fetchJson, observeValueAndInvalidate } from './fetch-json'
+import { sha256 } from '@noble/hashes/sha2.js'
+import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js'
+
+/** Base58 alphabet used by Tron */
+const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+const BalanceResponseSchema = z.union([
+  z.string(),
+  z.number().transform((v) => String(v)),
+])
+
+const TronHistorySchema = z.looseObject({
+  data: z.array(z.unknown()),
+  success: z.boolean(),
+  fingerprint: z.string().optional(),
+})
+
+const TronNativeTxSchema = z.looseObject({
+  contractRet: z.string().optional(),
+  txID: z.string(),
+  blockNumber: z.number().optional(),
+  from: z.string(),
+  to: z.string(),
+  amount: z.number(),
+  timestamp: z.number(),
+})
+
+const TronTrc20TxSchema = z.looseObject({
+  txID: z.string(),
+  from: z.string(),
+  to: z.string(),
+  value: z.string(),
+  token_symbol: z.string(),
+  token_address: z.string(),
+  token_name: z.string(),
+  token_decimals: z.number(),
+  timestamp: z.number(),
+})
+
+type TronNativeTx = z.infer<typeof TronNativeTxSchema>
+type TronTrc20Tx = z.infer<typeof TronTrc20TxSchema>
+
+const FETCH_MULTIPLIER = 5
+
+function decodeBase58(str: string): Uint8Array {
+  let num = BigInt(0)
+  for (const char of str) {
+    const index = ALPHABET.indexOf(char)
+    if (index === -1) throw new Error('Invalid base58')
+    num = num * 58n + BigInt(index)
+  }
+
+  const hex = num.toString(16).padStart(50, '0')
+  const bytes = new Uint8Array(25)
+  for (let i = 0; i < 25; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+function encodeBase58(bytes: Uint8Array): string {
+  let num = BigInt(0)
+  for (const byte of bytes) {
+    num = num * 256n + BigInt(byte)
+  }
+
+  let result = ''
+  while (num > 0n) {
+    const rem = Number(num % 58n)
+    num = num / 58n
+    result = ALPHABET[rem] + result
+  }
+
+  for (const byte of bytes) {
+    if (byte === 0) result = ALPHABET[0] + result
+    else break
+  }
+
+  return result
+}
+
+function tronBase58ToHex(address: string): string {
+  const decoded = decodeBase58(address)
+  const payload = decoded.slice(0, 21)
+  return bytesToHex(payload)
+}
+
+function tronHexToBase58(hexAddress: string): string {
+  const raw = hexAddress.startsWith('0x') ? hexAddress.slice(2) : hexAddress
+  const payload = hexToBytes(raw)
+  const checksum = sha256(sha256(payload)).slice(0, 4)
+  const full = new Uint8Array([...payload, ...checksum])
+  return encodeBase58(full)
+}
+
+function toTronBase58Address(address: string): string {
+  return address.startsWith('T') ? address : tronHexToBase58(address)
+}
+
+function getDirection(from: string, to: string, normalizedAddress: string): Direction {
+  const fromLower = from.toLowerCase()
+  const toLower = to.toLowerCase()
+
+  if (fromLower === normalizedAddress && toLower === normalizedAddress) return 'self'
+  if (fromLower === normalizedAddress) return 'out'
+  return 'in'
+}
+
+export class TronWalletProvider implements ApiProvider {
+  readonly type: string
+  readonly endpoint: string
+  readonly config?: Record<string, unknown>
+
+  private readonly chainId: string
+  private readonly symbol: string
+  private readonly decimals: number
+
+  constructor(entry: ParsedApiEntry, chainId: string) {
+    this.type = entry.type
+    this.endpoint = entry.endpoint
+    this.config = entry.config
+    this.chainId = chainId
+    this.symbol = chainConfigService.getSymbol(chainId)
+    this.decimals = chainConfigService.getDecimals(chainId)
+  }
+
+  get supportsNativeBalance() {
+    return true
+  }
+
+  get supportsTransactionHistory() {
+    return true
+  }
+
+  async getNativeBalance(address: string): Promise<Balance> {
+    const hexAddress = address.startsWith('T') ? tronBase58ToHex(address) : address
+    const url = new URL(`${this.endpoint}/balance`)
+    url.searchParams.set('address', hexAddress)
+
+    const json: unknown = await fetchJson(url.toString(), undefined, {
+      cacheKey: `tronwallet:${this.chainId}:balance:${address}`,
+      ttlMs: 60_000,
+      tags: [`balance:${this.chainId}:${address}`],
+    })
+    const parsed = BalanceResponseSchema.safeParse(json)
+    if (!parsed.success) {
+      throw new Error('Invalid API response')
+    }
+
+    observeValueAndInvalidate({
+      key: `balance:${this.chainId}:${address}`,
+      value: parsed.data,
+      invalidateTags: [`txhistory:${this.chainId}:${address}`],
+    })
+
+    return {
+      amount: Amount.fromRaw(parsed.data, this.decimals, this.symbol),
+      symbol: this.symbol,
+    }
+  }
+
+  async getTransactionHistory(address: string, limit = 20): Promise<Transaction[]> {
+    const fetchLimit = limit * FETCH_MULTIPLIER
+    const hexAddress = address.startsWith('T') ? tronBase58ToHex(address) : address
+
+    const [nativeTxs, trc20Txs] = await Promise.all([
+      this.fetchHistory<TronNativeTx>(
+        `${this.endpoint}/trans/common/history`,
+        hexAddress,
+        address,
+        fetchLimit,
+        TronNativeTxSchema,
+        'common',
+      ),
+      this.fetchHistory<TronTrc20Tx>(
+        `${this.endpoint}/trans/trc20/history`,
+        hexAddress,
+        address,
+        fetchLimit,
+        TronTrc20TxSchema,
+        'trc20',
+      ),
+    ])
+
+    const normalizedAddress = address.toLowerCase()
+    const tokenById = new Map<string, TronTrc20Tx[]>()
+    for (const t of trc20Txs) {
+      const id = t.txID.toLowerCase()
+      const existing = tokenById.get(id) ?? []
+      existing.push(t)
+      tokenById.set(id, existing)
+    }
+
+    const results: Transaction[] = []
+    const processed = new Set<string>()
+
+    for (const tx of nativeTxs) {
+      const id = tx.txID.toLowerCase()
+      if (processed.has(id)) continue
+      processed.add(id)
+
+      const relatedTokens = tokenById.get(id) ?? []
+      if (relatedTokens.length > 0) {
+        const primary = relatedTokens[0]
+        const from = toTronBase58Address(primary.from)
+        const to = toTronBase58Address(primary.to)
+        results.push({
+          hash: primary.txID,
+          from,
+          to,
+          timestamp: primary.timestamp,
+          status: 'confirmed',
+          blockNumber: tx.blockNumber !== undefined ? BigInt(tx.blockNumber) : undefined,
+          action: 'transfer',
+          direction: getDirection(from, to, normalizedAddress),
+          assets: [
+            {
+              assetType: 'token' as const,
+              value: primary.value,
+              symbol: primary.token_symbol,
+              decimals: primary.token_decimals,
+              contractAddress: toTronBase58Address(primary.token_address),
+              name: primary.token_name,
+            },
+          ],
+        })
+        continue
+      }
+
+      const from = toTronBase58Address(tx.from)
+      const to = toTronBase58Address(tx.to)
+      results.push({
+        hash: tx.txID,
+        from,
+        to,
+        timestamp: tx.timestamp,
+        status: 'confirmed',
+        blockNumber: tx.blockNumber !== undefined ? BigInt(tx.blockNumber) : undefined,
+        action: 'transfer',
+        direction: getDirection(from, to, normalizedAddress),
+        assets: [
+          {
+            assetType: 'native' as const,
+            value: String(tx.amount),
+            symbol: this.symbol,
+            decimals: this.decimals,
+          },
+        ],
+      })
+    }
+
+    for (const tx of trc20Txs) {
+      const id = tx.txID.toLowerCase()
+      if (processed.has(id)) continue
+      processed.add(id)
+
+      const from = toTronBase58Address(tx.from)
+      const to = toTronBase58Address(tx.to)
+      results.push({
+        hash: tx.txID,
+        from,
+        to,
+        timestamp: tx.timestamp,
+        status: 'confirmed',
+        action: 'transfer',
+        direction: getDirection(from, to, normalizedAddress),
+        assets: [
+          {
+            assetType: 'token' as const,
+            value: tx.value,
+            symbol: tx.token_symbol,
+            decimals: tx.token_decimals,
+            contractAddress: toTronBase58Address(tx.token_address),
+            name: tx.token_name,
+          },
+        ],
+      })
+    }
+
+    return results
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .slice(0, limit)
+  }
+
+  private async fetchHistory<T>(
+    url: string,
+    hexAddress: string,
+    tagAddress: string,
+    limit: number,
+    itemSchema: z.ZodType<T>,
+    kind: string,
+  ): Promise<T[]> {
+    const json: unknown = await fetchJson(
+      url,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ address: hexAddress, limit }),
+      },
+      {
+        cacheKey: `tronwallet:${this.chainId}:${kind}:${hexAddress}:${limit}`,
+        ttlMs: 5 * 60_000,
+        tags: [`txhistory:${this.chainId}:${tagAddress}`],
+      },
+    )
+
+    const parsed = TronHistorySchema.safeParse(json)
+    if (!parsed.success || !parsed.data.success) {
+      throw new Error('Upstream API error')
+    }
+
+    return parsed.data.data
+      .map((item) => itemSchema.safeParse(item))
+      .filter((r): r is z.SafeParseSuccess<T> => r.success)
+      .map((r) => r.data)
+  }
+}
+
+export function createTronwalletProvider(entry: ParsedApiEntry, chainId: string): ApiProvider | null {
+  if (entry.type === 'tronwallet-v1') {
+    return new TronWalletProvider(entry, chainId)
+  }
+  return null
+}

--- a/src/services/chain-config/index.ts
+++ b/src/services/chain-config/index.ts
@@ -1,4 +1,4 @@
-export type { ChainConfig, ChainConfigSource, ChainConfigSubscription, ChainKind, ParsedApiEntry, ApiEntry, ApiConfig } from './types'
+export type { ChainConfig, ChainConfigSource, ChainConfigSubscription, ChainKind, ParsedApiEntry, ApiProviderEntry, ApiProviders } from './types'
 export { chainConfigService } from './service'
 
 import { ChainConfigListSchema, ChainConfigSchema, ChainConfigSubscriptionSchema, VersionedChainConfigFileSchema } from './schema'

--- a/src/services/chain-config/service.ts
+++ b/src/services/chain-config/service.ts
@@ -6,7 +6,7 @@
  */
 
 import { chainConfigStore, chainConfigSelectors } from '@/stores/chain-config'
-import type { ApiEntry, ChainConfig, ParsedApiEntry } from './types'
+import type { ChainConfig, ParsedApiEntry } from './types'
 
 class ChainConfigService {
   /**
@@ -22,13 +22,7 @@ class ChainConfigService {
    */
   getApi(chainId: string): ParsedApiEntry[] {
     const config = this.getConfig(chainId)
-    if (!config?.api) return []
-
-    const entries: ParsedApiEntry[] = []
-    for (const [type, entry] of Object.entries(config.api)) {
-      entries.push(this.parseApiEntry(type, entry as ApiEntry))
-    }
-    return entries
+    return config?.apis ?? []
   }
 
   /**
@@ -46,17 +40,6 @@ class ChainConfigService {
     const entries = this.getApi(chainId)
     const regex = new RegExp('^' + pattern.replace('*', '.*') + '$')
     return entries.find((e) => regex.test(e.type)) ?? null
-  }
-
-  /**
-   * 解析 API 配置项
-   */
-  private parseApiEntry(type: string, entry: ApiEntry): ParsedApiEntry {
-    if (typeof entry === 'string') {
-      return { type, endpoint: entry }
-    }
-    const [endpoint, config] = entry
-    return { type, endpoint, config }
   }
 
   // ========== 便捷方法 (用于 Adapter) ==========

--- a/src/services/chain-config/storage.ts
+++ b/src/services/chain-config/storage.ts
@@ -126,7 +126,7 @@ export async function saveChainConfigs(options: {
       decimals: config.decimals,
       ...(config.icon !== undefined ? { icon: config.icon } : {}),
       ...(config.prefix !== undefined ? { prefix: config.prefix } : {}),
-      ...(config.api !== undefined ? { api: config.api } : {}),
+      ...(config.apis !== undefined ? { apis: config.apis } : {}),
       ...(config.explorer !== undefined ? { explorer: config.explorer } : {}),
     }
 

--- a/src/services/chain-config/types.ts
+++ b/src/services/chain-config/types.ts
@@ -7,8 +7,8 @@
 import type { z } from 'zod'
 
 import {
-  ApiConfigSchema,
-  ApiEntrySchema,
+  ApiProviderEntrySchema,
+  ApiProvidersSchema,
   ChainConfigListSchema,
   ChainConfigSchema,
   ChainConfigSourceSchema,
@@ -25,14 +25,9 @@ export type ChainConfig = z.infer<typeof ChainConfigSchema>
 export type ChainConfigList = z.infer<typeof ChainConfigListSchema>
 export type ChainConfigSubscription = z.infer<typeof ChainConfigSubscriptionSchema>
 
-/** API 配置项 (url | [url, config]) */
-export type ApiEntry = z.infer<typeof ApiEntrySchema>
-/** API 配置对象 Record<providerType, ApiEntry> */
-export type ApiConfig = z.infer<typeof ApiConfigSchema>
+/** API provider entry (ordered) */
+export type ApiProviderEntry = z.infer<typeof ApiProviderEntrySchema>
+export type ApiProviders = z.infer<typeof ApiProvidersSchema>
 
-/** 解析后的 API 条目，用于 Provider 初始化 */
-export interface ParsedApiEntry {
-  type: string
-  endpoint: string
-  config?: Record<string, unknown>
-}
+/** provider 初始化需要的条目（当前与 ApiProviderEntry 结构一致） */
+export type ParsedApiEntry = ApiProviderEntry


### PR DESCRIPTION
- Breaking: chain config uses ordered apis[] (api removed)\n- Add walletapi-backed providers: ethwallet-v1 / tronwallet-v1 / btcwallet-v1\n- ChainProvider.getMethod now falls back by provider order\n- Add fetchJson in-flight dedupe + TTL cache + tag invalidation\n- Add TEST_REAL_API-gated real-provider sanity (eth/tron/btc)\n\nNotes:\n- Secrets are not committed; TronGrid key is read via env var VITE_TRONGRID_API_KEY when configured.