### PR TITLE
fix(cd): switch to gh-pages branch deployment with force-push

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -449,11 +449,19 @@ jobs:
             bun scripts/build.ts dweb --upload --skip-typecheck --skip-test
           fi
 
-      # ===== 上传构建产物 =====
-      - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: gh-pages
+      # ===== 部署到 GitHub Pages (Force Push) =====
+      - name: Deploy to GitHub Pages
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          cd gh-pages
+          git init
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Deploy to GitHub Pages - ${{ github.sha }}"
+          git push -f "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" HEAD:gh-pages
+          echo "Deployed to gh-pages branch"
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v4
@@ -461,22 +469,6 @@ jobs:
           name: release-${{ steps.channel.outputs.channel }}-${{ steps.version.outputs.version }}
           path: release/
           retention-days: 30
-
-  # ==================== 部署到 GitHub Pages (GitHub-hosted only) ====================
-  # Self-hosted 版本直接在 build-fast 中用 git push 部署，避免 upload-pages-artifact 卡住
-  deploy-pages-standard:
-    if: vars.USE_SELF_HOSTED != 'true'
-    needs: build-standard
-    runs-on: ubuntu-latest
-
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
 
   # ==================== 创建 Release (GitHub-hosted) ====================
   create-release-standard:


### PR DESCRIPTION
## 修改内容

- 移除  任务，不再使用 。
- 在  任务中，使用  将构建产物直接推送到  分支。
- 统一了 self-hosted 和 github-hosted 的部署逻辑。

## 原因

- 旧版  在某些情况下会出现上传卡住或失败的问题。
- 使用  分支配合 force-push 可以确保不保留历史记录，减小仓库体积。

## 注意事项

合并此 PR 后，请确保仓库的 **Settings > Pages > Build and deployment > Source** 已设置为 **Deploy from a branch**，并将分支选择为 **gh-pages** (/root)。