### PR TITLE
fix(storybook): replace deprecated 'creditcard' icon with 'credit'

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -99,7 +99,7 @@ const preview: Preview = {
       description: 'Fiat display currency (default USD)',
       defaultValue: 'USD',
       toolbar: {
-        icon: 'creditcard',
+        icon: 'credit',
         items: supportedCurrencyCodes.map((code) => ({
           value: code,
           title: `${currencies[code].symbol} ${code}`,


### PR DESCRIPTION
修复 Storybook 启动时的废弃警告：

```
Use of an unknown prop (creditcard) in the Icons component. The Icons component is deprecated.
```

将 `.storybook/preview.tsx` 中 currency globalType toolbar 的 `icon: 'creditcard'` 替换为有效的图标名称 `icon: 'credit'`。