### PR TITLE
fix(wallet): show 'not supported' instead of loading for unsupported providers

### DIFF
--- a/docs/white-book/04-服务篇/01-服务架构/api-providers-status.md
+++ b/docs/white-book/04-服务篇/01-服务架构/api-providers-status.md
@@ -10,7 +10,7 @@
 |---|---|---|---|---|---|---|
 | **ETH** | `blockscout-v1` | `eth.blockscout.com` | ✅ 正常 | ✅ | ✅ | 推荐使用，完全免费且稳定 |
 | **ETH** | `ethereum-rpc` | `ethereum-rpc.publicnode.com` | ⚠️ 部分 | ✅ | ❌ | RPC 仅支持余额查询，不支持交易历史 |
-| **ETH** | `etherscan-v2` | `api.etherscan.io` | ❌ 需鉴权 | ❌ | ❌ | 需要配置 `ETHERSCAN_API_KEY` |
+| **ETH** | `etherscan-v2` | `api.etherscan.io` | ✅ 正常 | ✅ | ✅ | 需要配置 `ETHERSCAN_API_KEY`（已配置） |
 | **ETH** | `ethwallet-v1` | `walletapi.bfmeta.info` | ✅ 正常 | ✅ | ✅ | 自研 API，PR #174 已修复 Schema 问题 |
 | **BNB** | `bsc-rpc` | `bsc-rpc.publicnode.com` | ⚠️ 部分 | ✅ | ❌ | RPC 仅支持余额查询 |
 | **BSC** | `etherscan-v2` | `api.etherscan.io` | ❌ 需付费 | ❌ | ❌ | BSC 链在 Etherscan V2 中需要付费 Plan |
@@ -26,9 +26,10 @@
 - **原因**: 即使是活跃地址也无法获取交易，可能是后端 BSC 模块数据同步问题或 BscScan V1 源失效。
 - **建议**: 暂时依赖 RPC 查询余额，交易记录需等待后端修复。
 
-### 2. Etherscan V2 鉴权
-- **现象**: 返回 `Missing/Invalid API Key`。
+### 2. Etherscan V2 鉴权（ETH 链已解决）
+- **原现象**: 返回 `Missing/Invalid API Key`。
 - **配置**: 需要在环境变量中设置 `ETHERSCAN_API_KEY`。
+- **状态**: ETH 链已配置 API Key，正常可用。
 - **注意**: BSC 链即使有 Key，普通免费 Plan 也不支持通过统一入口访问，需要使用独立的 BscScan API（V1 已弃用，需迁移到 V2）。
 
 ### 3. BTC WalletAPI (已修复)

--- a/src/components/wallet/wallet-address-portfolio-from-provider.tsx
+++ b/src/components/wallet/wallet-address-portfolio-from-provider.tsx
@@ -135,9 +135,18 @@ export function WalletAddressPortfolioFromProvider({
     staleTime: 30_000,
   })
 
-  // Show loading if provider not ready OR query is loading
-  const tokensLoading = !tokensEnabled || tokensQuery.isLoading
-  const transactionsLoading = !transactionsEnabled || transactionsQuery.isLoading
+  // Loading 状态：只有当 query 正在执行时才显示 loading
+  // 当 provider 不支持时，不显示 loading，而是直接显示"不支持"提示
+  const tokensLoading = tokensEnabled && tokensQuery.isLoading
+  const transactionsLoading = transactionsEnabled && transactionsQuery.isLoading
+
+  // Supported 状态：当 provider 明确不支持时，supported 应为 false
+  const tokensSupported = tokensEnabled
+    ? (tokensQuery.data?.supported ?? true)
+    : false
+  const transactionsSupported = transactionsEnabled
+    ? (transactionsQuery.data?.supported ?? true)
+    : false
 
   return (
     <WalletAddressPortfolioView
@@ -148,10 +157,10 @@ export function WalletAddressPortfolioFromProvider({
       tokensLoading={tokensLoading}
       transactionsLoading={transactionsLoading}
       tokensRefreshing={tokensQuery.isFetching && !tokensQuery.isLoading}
-      tokensSupported={tokensQuery.data?.supported ?? true}
-      tokensFallbackReason={tokensQuery.data?.fallbackReason}
-      transactionsSupported={transactionsQuery.data?.supported ?? true}
-      transactionsFallbackReason={transactionsQuery.data?.fallbackReason}
+      tokensSupported={tokensSupported}
+      tokensFallbackReason={tokensEnabled ? tokensQuery.data?.fallbackReason : 'Provider does not support token balance queries'}
+      transactionsSupported={transactionsSupported}
+      transactionsFallbackReason={transactionsEnabled ? transactionsQuery.data?.fallbackReason : 'Provider does not support transaction history queries'}
       onTokenClick={onTokenClick}
       onTransactionClick={onTransactionClick}
       className={className}


### PR DESCRIPTION
## Problem
When a provider doesn't support transaction history (like `ethereum-rpc`), the UI shows infinite loading instead of a 'not supported' message.

## Root Cause
In `wallet-address-portfolio-from-provider.tsx`:
```tsx
const transactionsLoading = !transactionsEnabled || transactionsQuery.isLoading
```
When `transactionsEnabled = false`, `transactionsLoading` is always `true`.

## Fix
- Change loading logic to use AND: `transactionsEnabled && transactionsQuery.isLoading`
- When provider doesn't support a feature, immediately show fallback warning
- Also update etherscan-v2 status in whitebook (API key is configured)

## Changes
- `src/components/wallet/wallet-address-portfolio-from-provider.tsx`
- `docs/white-book/04-服务篇/01-服务架构/api-providers-status.md`