### PR TITLE
fix(onboarding): default select all chains in chain selector

### DIFF
--- a/src/components/onboarding/chain-selector.test.tsx
+++ b/src/components/onboarding/chain-selector.test.tsx
@@ -129,8 +129,8 @@ describe('ChainSelector', () => {
 });
 
 describe('getDefaultSelectedChains', () => {
-  it('returns bioforest chain ids only', () => {
+  it('returns all chain ids', () => {
     const defaults = getDefaultSelectedChains(sampleChains);
-    expect(defaults).toEqual(['bfmeta', 'ccchain']);
+    expect(defaults).toEqual(['bfmeta', 'ccchain', 'ethereum', 'tron', 'bitcoin']);
   });
 });

--- a/src/components/onboarding/chain-selector.tsx
+++ b/src/components/onboarding/chain-selector.tsx
@@ -352,10 +352,8 @@ export function ChainSelector({
 }
 
 /**
- * 获取默认选择的链（生物链林）
+ * 获取默认选择的链（全选）
  */
 export function getDefaultSelectedChains(chains: ChainConfig[]): string[] {
-  return chains
-    .filter(chain => chain.chainKind === 'bioforest')
-    .map(chain => chain.id);
+  return chains.map(chain => chain.id);
 }


### PR DESCRIPTION
修改链选择器默认全选所有区块链网络，而不是只选择 bioforest 类型的链。