### PR TITLE
feat(chain): add BFMetaV2 chain and simplify biowallet-v1 endpoint

### DIFF
--- a/public/configs/default-chains.json
+++ b/public/configs/default-chains.json
@@ -2,6 +2,22 @@
   "version": "2.0.0",
   "chains": [
     {
+      "id": "bfmetav2",
+      "version": "1.0",
+      "chainKind": "bioforest",
+      "name": "BFMeta V2",
+      "symbol": "BFM",
+      "icon": "../icons/bfmeta/chain.svg",
+      "tokenIconBase": [
+        "../icons/bfmeta/tokens",
+        "https://bfm-fonts-cdn.oss-cn-hongkong.aliyuncs.com/meta-icon/bfm",
+        "https://raw.githubusercontent.com/BFChainMeta/fonts-cdn/main/src/meta-icon/bfm"
+      ],
+      "prefix": "b",
+      "decimals": 8,
+      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bf-meta.org/wallet/bfmetav2" }]
+    },
+    {
       "id": "bfmeta",
       "version": "1.0",
       "chainKind": "bioforest",
@@ -15,7 +31,7 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info", "config": { "path": "bfm" } }],
+      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info/wallet/bfm" }],
       "explorer": {
         "url": "https://tracker.bfmeta.org",
         "queryTx": "https://tracker.bfmeta.org/#/info/event-details/:signature",
@@ -37,7 +53,7 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info", "config": { "path": "ccchain" } }]
+      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info/wallet/ccchain" }]
     },
     {
       "id": "pmchain",
@@ -53,7 +69,7 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info", "config": { "path": "pmchain" } }]
+      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info/wallet/pmchain" }]
     },
     {
       "id": "bfchainv2",
@@ -69,9 +85,7 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "apis": [
-        { "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info", "config": { "path": "bfchainv2" } }
-      ]
+      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info/wallet/bfchainv2" }]
     },
     {
       "id": "btgmeta",
@@ -87,7 +101,7 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info", "config": { "path": "btgmeta" } }]
+      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info/wallet/btgmeta" }]
     },
     {
       "id": "biwmeta",
@@ -101,9 +115,7 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "apis": [
-        { "type": "biowallet-v1", "endpoint": "https://walletapi.biw-meta.com", "config": { "path": "biwmeta" } }
-      ],
+      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.biw-meta.com/wallet/biwmeta" }],
       "explorer": {
         "url": "https://tracker.biw-meta.info",
         "queryTx": "https://tracker.biw-meta.info/#/info/event-details/:signature",
@@ -125,7 +137,7 @@
       ],
       "prefix": "b",
       "decimals": 8,
-      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info", "config": { "path": "ethmeta" } }]
+      "apis": [{ "type": "biowallet-v1", "endpoint": "https://walletapi.bfmeta.info/wallet/ethmeta" }]
     },
     {
       "id": "ethereum",

--- a/src/services/chain-adapter/providers/__tests__/biowallet-provider.bfmetav2.real.test.ts
+++ b/src/services/chain-adapter/providers/__tests__/biowallet-provider.bfmetav2.real.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { BiowalletProvider } from '../biowallet-provider';
+import type { ParsedApiEntry } from '@/services/chain-config';
+
+vi.mock('@/services/chain-config', () => ({
+  chainConfigService: {
+    getSymbol: () => 'BFM',
+    getDecimals: () => 8,
+  },
+}));
+
+const mockFetch = vi.fn();
+const originalFetch = global.fetch;
+global.fetch = mockFetch;
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+function readFixture<T>(name: string): T {
+  const dir = path.dirname(fileURLToPath(import.meta.url));
+  const filePath = path.join(dir, 'fixtures/real', name);
+  return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+}
+
+describe('BiowalletProvider (BFMetaV2 real fixtures)', () => {
+  const entry: ParsedApiEntry = {
+    type: 'biowallet-v1',
+    endpoint: 'https://walletapi.bf-meta.org/wallet/bfmetav2',
+  };
+
+  const lastblock = readFixture<any>('bfmetav2-lastblock.json');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses endpoint directly without path concatenation', () => {
+    const provider = new BiowalletProvider(entry, 'bfmetav2');
+    expect(provider.endpoint).toBe('https://walletapi.bf-meta.org/wallet/bfmetav2');
+  });
+
+  it('fetches block height from the correct endpoint', async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url === 'https://walletapi.bf-meta.org/wallet/bfmetav2/lastblock') {
+        return { ok: true, json: async () => lastblock };
+      }
+      return { ok: false, status: 404 };
+    });
+
+    const provider = new BiowalletProvider(entry, 'bfmetav2');
+    const height = await provider.getBlockHeight();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://walletapi.bf-meta.org/wallet/bfmetav2/lastblock',
+      undefined
+    );
+    expect(height).toBe(BigInt(45052));
+  });
+
+  it('converts transferAsset (AST-02) to transfer + native asset', async () => {
+    const query = readFixture<any>('bfmetav2-transactions-query.json');
+    const tx = query.result.trs[0].transaction;
+
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/lastblock')) {
+        return { ok: true, json: async () => lastblock };
+      }
+      if (url.endsWith('/transactions/query')) {
+        expect(init?.method).toBe('POST');
+        return { ok: true, json: async () => query };
+      }
+      return { ok: false, status: 404 };
+    });
+
+    const provider = new BiowalletProvider(entry, 'bfmetav2');
+    const txs = await provider.getTransactionHistory(tx.recipientId, 10);
+
+    expect(txs.length).toBeGreaterThan(0);
+    expect(txs[0].action).toBe('transfer');
+    expect(txs[0].direction).toBe('in');
+    expect(txs[0].assets[0]).toMatchObject({
+      assetType: 'native',
+      symbol: 'BFM',
+      decimals: 8,
+      value: '444',
+    });
+  });
+
+  it('queries address assets from the correct endpoint', async () => {
+    const assetResponse = {
+      success: true,
+      result: {
+        address: 'bPbubZwJGSJBB3feZpsvttMFj8spu1jCm2',
+        assets: {
+          GAGGQ: {
+            BFM: { assetNumber: '1000000000', assetType: 'BFM' },
+          },
+        },
+      },
+    };
+
+    mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === 'https://walletapi.bf-meta.org/wallet/bfmetav2/address/asset') {
+        expect(init?.method).toBe('POST');
+        return { ok: true, json: async () => assetResponse };
+      }
+      return { ok: false, status: 404 };
+    });
+
+    const provider = new BiowalletProvider(entry, 'bfmetav2');
+    const balance = await provider.getNativeBalance('bPbubZwJGSJBB3feZpsvttMFj8spu1jCm2');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://walletapi.bf-meta.org/wallet/bfmetav2/address/asset',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(balance.symbol).toBe('BFM');
+    expect(balance.amount.toRawString()).toBe('1000000000');
+  });
+});

--- a/src/services/chain-adapter/providers/__tests__/biowallet-provider.biwmeta.real.test.ts
+++ b/src/services/chain-adapter/providers/__tests__/biowallet-provider.biwmeta.real.test.ts
@@ -29,8 +29,7 @@ function readFixture<T>(name: string): T {
 describe('BiowalletProvider (BIWMeta real fixtures)', () => {
   const entry: ParsedApiEntry = {
     type: 'biowallet-v1',
-    endpoint: 'https://walletapi.bfmeta.info',
-    config: { path: 'biwmeta' },
+    endpoint: 'https://walletapi.biw-meta.com/wallet/biwmeta',
   };
 
   const lastblock = readFixture<any>('biwmeta-lastblock.json');
@@ -44,10 +43,10 @@ describe('BiowalletProvider (BIWMeta real fixtures)', () => {
     const tx = query.result.trs[0].transaction;
 
     mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (url.endsWith('/wallet/biwmeta/lastblock')) {
+      if (url.endsWith('/lastblock')) {
         return { ok: true, json: async () => lastblock };
       }
-      if (url.endsWith('/wallet/biwmeta/transactions/query')) {
+      if (url.endsWith('/transactions/query')) {
         expect(init?.method).toBe('POST');
         return { ok: true, json: async () => query };
       }
@@ -73,10 +72,10 @@ describe('BiowalletProvider (BIWMeta real fixtures)', () => {
     const tx = query.result.trs[0].transaction;
 
     mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (url.endsWith('/wallet/biwmeta/lastblock')) {
+      if (url.endsWith('/lastblock')) {
         return { ok: true, json: async () => lastblock };
       }
-      if (url.endsWith('/wallet/biwmeta/transactions/query')) {
+      if (url.endsWith('/transactions/query')) {
         expect(init?.method).toBe('POST');
         return { ok: true, json: async () => query };
       }
@@ -102,10 +101,10 @@ describe('BiowalletProvider (BIWMeta real fixtures)', () => {
     const tx = query.result.trs[0].transaction;
 
     mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (url.endsWith('/wallet/biwmeta/lastblock')) {
+      if (url.endsWith('/lastblock')) {
         return { ok: true, json: async () => lastblock };
       }
-      if (url.endsWith('/wallet/biwmeta/transactions/query')) {
+      if (url.endsWith('/transactions/query')) {
         expect(init?.method).toBe('POST');
         return { ok: true, json: async () => query };
       }
@@ -131,10 +130,10 @@ describe('BiowalletProvider (BIWMeta real fixtures)', () => {
     const tx = query.result.trs[0].transaction;
 
     mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (url.endsWith('/wallet/biwmeta/lastblock')) {
+      if (url.endsWith('/lastblock')) {
         return { ok: true, json: async () => lastblock };
       }
-      if (url.endsWith('/wallet/biwmeta/transactions/query')) {
+      if (url.endsWith('/transactions/query')) {
         expect(init?.method).toBe('POST');
         return { ok: true, json: async () => query };
       }
@@ -160,10 +159,10 @@ describe('BiowalletProvider (BIWMeta real fixtures)', () => {
     const tx = query.result.trs[0].transaction;
 
     mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (url.endsWith('/wallet/biwmeta/lastblock')) {
+      if (url.endsWith('/lastblock')) {
         return { ok: true, json: async () => lastblock };
       }
-      if (url.endsWith('/wallet/biwmeta/transactions/query')) {
+      if (url.endsWith('/transactions/query')) {
         expect(init?.method).toBe('POST');
         return { ok: true, json: async () => query };
       }

--- a/src/services/chain-adapter/providers/__tests__/biowallet-provider.real.test.ts
+++ b/src/services/chain-adapter/providers/__tests__/biowallet-provider.real.test.ts
@@ -29,8 +29,7 @@ function readFixture<T>(name: string): T {
 describe('BiowalletProvider (real fixtures)', () => {
   const entry: ParsedApiEntry = {
     type: 'biowallet-v1',
-    endpoint: 'https://walletapi.bfmeta.info',
-    config: { path: 'bfm' },
+    endpoint: 'https://walletapi.bfmeta.info/wallet/bfm',
   }
 
   beforeEach(() => {
@@ -43,10 +42,10 @@ describe('BiowalletProvider (real fixtures)', () => {
     const query = readFixture<any>('bfmeta-transactions-query.json')
 
     mockFetch.mockImplementation(async (url: string, init?: RequestInit) => {
-      if (url.endsWith('/wallet/bfm/lastblock')) {
+      if (url.endsWith('/lastblock')) {
         return { ok: true, json: async () => lastblock }
       }
-      if (url.endsWith('/wallet/bfm/transactions/query')) {
+      if (url.endsWith('/transactions/query')) {
         expect(init?.method).toBe('POST')
         return { ok: true, json: async () => query }
       }

--- a/src/services/chain-adapter/providers/__tests__/fixtures/real/bfmetav2-lastblock.json
+++ b/src/services/chain-adapter/providers/__tests__/fixtures/real/bfmetav2-lastblock.json
@@ -1,0 +1,13 @@
+{
+  "success": true,
+  "result": {
+    "height": 45052,
+    "timestamp": 1472055,
+    "blockSize": 492,
+    "signature": "b9630bbdd9c5745fa89ec7c2b59cc5385e5e618377334d356a31c68c19a19ac69038e02d23f224f72c524cbda0d5990cf335d42f0ffbec72ac310d1e4354eb04",
+    "generatorPublicKey": "ab7b49784a710c1afb2e522553934b02392b4a89778f882b1d911de10d2c4c63",
+    "previousBlockSignature": "b010a5355bd83650c4e8b38afc579c2dc136b473e6d26ed5be697fcd40ecc7b01aef2ea99395dde3de8e52d97d64dc41ffa9da4190a80bd4713f5db66889ca0e",
+    "reward": "1000000000",
+    "magic": "GAGGQ"
+  }
+}

--- a/src/services/chain-adapter/providers/__tests__/fixtures/real/bfmetav2-transactions-query.json
+++ b/src/services/chain-adapter/providers/__tests__/fixtures/real/bfmetav2-transactions-query.json
@@ -1,0 +1,40 @@
+{
+  "success": true,
+  "result": {
+    "trs": [
+      {
+        "tIndex": 3,
+        "height": 1,
+        "signature": "f4b1b23bd4e0618d98f859fa3a9235a7babfb011298955f0c5dbbf9919cf33517f284b19bb0045dc6a2dfc99465bafc300fde6f31198375cf4bf9fb894f64306",
+        "transaction": {
+          "version": 1,
+          "type": "BFM-BFMETAV2-AST-02",
+          "senderId": "b54ACZhWTyHDTxiZumQcksKMwa1zhuejKe",
+          "senderPublicKey": "013233143c0074592c733ff4c2d4fcde3c697d7b30e1638e90b0fb9e9c2fc90d",
+          "rangeType": 0,
+          "range": [],
+          "fee": "82",
+          "timestamp": 0,
+          "fromMagic": "GAGGQ",
+          "toMagic": "GAGGQ",
+          "applyBlockHeight": 1,
+          "effectiveBlockHeight": 1,
+          "signature": "47cc4d38322ae3af7f9126086f3b1ea7c49ba1bbf3dab0f246ed8a428c2babc98dda2034ebe80ac92276e3561fdbfdc0f067da38cc0fa6861d3bb017be1ece05",
+          "remark": {},
+          "asset": {
+            "transferAsset": {
+              "sourceChainName": "bfmetav2",
+              "sourceChainMagic": "GAGGQ",
+              "assetType": "BFM",
+              "amount": "444"
+            }
+          },
+          "recipientId": "bPbubZwJGSJBB3feZpsvttMFj8spu1jCm2",
+          "storageKey": "assetType",
+          "storageValue": "BFM"
+        }
+      }
+    ],
+    "count": 1
+  }
+}

--- a/src/services/chain-adapter/providers/__tests__/integration.test.ts
+++ b/src/services/chain-adapter/providers/__tests__/integration.test.ts
@@ -72,7 +72,7 @@ describe('ChainProvider 集成测试', () => {
       prefix: 'b',
       enabled: true,
       source: 'default',
-      apis: [{ type: 'biowallet-v1', endpoint: 'https://walletapi.bfmeta.info', config: { path: 'bfmeta' } }],
+      apis: [{ type: 'biowallet-v1', endpoint: 'https://walletapi.bfmeta.info/wallet/bfm' }],
     }
     mockGetChainById.mockReturnValue(mockBfmetaConfig)
 
@@ -84,6 +84,38 @@ describe('ChainProvider 集成测试', () => {
     // 检查是否有 biowallet provider
     const biowalletProvider = providers.find(p => p.type.includes('biowallet'))
     expect(biowalletProvider).toBeDefined()
+    
+    // 检查能力
+    expect(provider.supportsTransactionHistory).toBe(true)
+    expect(provider.supportsNativeBalance).toBe(true)
+  })
+
+  it('为 BFMeta V2 链创建正确的 providers', () => {
+    const mockBfmetav2Config: ChainConfig = {
+      id: 'bfmetav2',
+      version: '1.0',
+      chainKind: 'bioforest',
+      name: 'BFMeta V2',
+      symbol: 'BFM',
+      decimals: 8,
+      prefix: 'b',
+      enabled: true,
+      source: 'default',
+      apis: [{ type: 'biowallet-v1', endpoint: 'https://walletapi.bf-meta.org/wallet/bfmetav2' }],
+    }
+    mockGetChainById.mockReturnValue(mockBfmetav2Config)
+
+    const provider = createChainProvider('bfmetav2')
+    
+    const providers = provider.getProviders()
+    expect(providers.length).toBeGreaterThanOrEqual(1)
+    
+    // 检查是否有 biowallet provider
+    const biowalletProvider = providers.find(p => p.type.includes('biowallet'))
+    expect(biowalletProvider).toBeDefined()
+    
+    // biowallet provider 应该直接使用 endpoint，无需 path 拼接
+    expect(biowalletProvider?.endpoint).toBe('https://walletapi.bf-meta.org/wallet/bfmetav2')
     
     // 检查能力
     expect(provider.supportsTransactionHistory).toBe(true)

--- a/src/services/chain-adapter/providers/biowallet-provider.ts
+++ b/src/services/chain-adapter/providers/biowallet-provider.ts
@@ -90,7 +90,6 @@ export class BiowalletProvider implements ApiProvider {
   readonly config?: Record<string, unknown>
   
   private readonly chainId: string
-  private readonly path: string
   private readonly symbol: string
   private readonly decimals: number
 
@@ -99,13 +98,12 @@ export class BiowalletProvider implements ApiProvider {
     this.endpoint = entry.endpoint
     this.config = entry.config
     this.chainId = chainId
-    this.path = (entry.config?.path as string) ?? chainId
     this.symbol = chainConfigService.getSymbol(chainId)
     this.decimals = chainConfigService.getDecimals(chainId)
   }
 
   private get baseUrl(): string {
-    return `${this.endpoint}/wallet/${this.path}`
+    return this.endpoint
   }
 
   async getNativeBalance(address: string): Promise<Balance> {
@@ -118,7 +116,7 @@ export class BiowalletProvider implements ApiProvider {
         body: JSON.stringify({ address }),
       },
       {
-        cacheKey: `biowallet:${this.path}:assets:${address}`,
+        cacheKey: `biowallet:${this.chainId}:assets:${address}`,
         ttlMs: 60_000,
         tags: [`balance:${this.chainId}:${address}`],
       },
@@ -166,7 +164,7 @@ export class BiowalletProvider implements ApiProvider {
         body: JSON.stringify({ address }),
       },
       {
-        cacheKey: `biowallet:${this.path}:assets:${address}`,
+        cacheKey: `biowallet:${this.chainId}:assets:${address}`,
         ttlMs: 60_000,
         tags: [`balance:${this.chainId}:${address}`],
       },
@@ -202,7 +200,7 @@ export class BiowalletProvider implements ApiProvider {
 
   async getTransactionHistory(address: string, limit = 20): Promise<Transaction[]> {
     const blockJson: unknown = await fetchJson(`${this.baseUrl}/lastblock`, undefined, {
-      cacheKey: `biowallet:${this.path}:lastblock`,
+      cacheKey: `biowallet:${this.chainId}:lastblock`,
       ttlMs: 10_000,
     })
     const blockParsed = BiowalletBlockSchema.safeParse(blockJson)
@@ -224,7 +222,7 @@ export class BiowalletProvider implements ApiProvider {
         }),
       },
       {
-        cacheKey: `biowallet:${this.path}:txs:${address}:${limit}:${maxHeight}`,
+        cacheKey: `biowallet:${this.chainId}:txs:${address}:${limit}:${maxHeight}`,
         ttlMs: 5 * 60_000,
         tags: [`txhistory:${this.chainId}:${address}`],
       },
@@ -413,7 +411,7 @@ export class BiowalletProvider implements ApiProvider {
 
   async getBlockHeight(): Promise<bigint> {
     const json: unknown = await fetchJson(`${this.baseUrl}/lastblock`, undefined, {
-      cacheKey: `biowallet:${this.path}:lastblock`,
+      cacheKey: `biowallet:${this.chainId}:lastblock`,
       ttlMs: 10_000,
     })
     const parsed = BiowalletBlockSchema.safeParse(json)


### PR DESCRIPTION
## Summary

- Add BFMetaV2 chain configuration (first in bioforest network)
  - Uses `walletapi.bf-meta.org/wallet/bfmetav2` endpoint
  - Reuses BFMeta icons
  - Symbol: BFM, prefix: b, decimals: 8

- Simplify biowallet-v1 provider: remove `config.path` logic
  - Endpoint now contains full path (e.g., `.../wallet/bfmetav2`)
  - Update all existing bioforest chains to use full endpoint URLs
  - Cleaner configuration, no path concatenation in code

- Add tests for BFMetaV2 chain
  - `biowallet-provider.bfmetav2.real.test.ts`
  - Test fixtures for lastblock and transactions
  - Integration test for BFMetaV2 provider creation

## Testing

- All biowallet provider tests pass (10/10)
- Typecheck passes
- API endpoint verified: `curl https://walletapi.bf-meta.org/wallet/bfmetav2/lastblock`