### PR TITLE
fix(biowallet): simplify API URL handling to use full endpoint URL

### DIFF
--- a/src/services/chain-adapter/__tests__/bioforest-api.test.ts
+++ b/src/services/chain-adapter/__tests__/bioforest-api.test.ts
@@ -29,7 +29,7 @@ vi.mock('@/services/chain-config/service', () => ({
     getRpcUrl: () => '',
     getDecimals: () => 8,
     getSymbol: () => 'BFM',
-    getBiowalletApi: () => ({ endpoint: 'https://walletapi.bfmeta.info', path: 'bfm' }),
+    getBiowalletApi: () => 'https://walletapi.bfmeta.info/wallet/bfm',
   },
 }))
 

--- a/src/services/chain-adapter/bioforest/asset-service.ts
+++ b/src/services/chain-adapter/bioforest/asset-service.ts
@@ -64,16 +64,14 @@ export class BioforestAssetService implements IAssetService {
 
   async getTokenBalances(address: Address): Promise<Balance[]> {
     const config = this.getConfig()
-    const biowalletApi = chainConfigService.getBiowalletApi(config.id)
+    const baseUrl = chainConfigService.getBiowalletApi(config.id)
 
-    if (!biowalletApi) {
+    if (!baseUrl) {
       return [this.getEmptyNativeBalance()]
     }
 
-    const { endpoint, path } = biowalletApi
-
     try {
-      const response = await fetch(`${endpoint}/wallet/${path}/address/asset`, {
+      const response = await fetch(`${baseUrl}/address/asset`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/services/chain-adapter/bioforest/chain-service.ts
+++ b/src/services/chain-adapter/bioforest/chain-service.ts
@@ -12,8 +12,7 @@ import type { BioforestBlockInfo, BioforestFeeInfo } from './types'
 export class BioforestChainService implements IChainService {
   private readonly chainId: string
   private config: ChainConfig | null = null
-  private apiUrl: string = ''
-  private apiPath: string = ''
+  private baseUrl: string = ''
 
   constructor(chainId: string) {
     this.chainId = chainId
@@ -29,9 +28,7 @@ export class BioforestChainService implements IChainService {
         )
       }
       this.config = config
-      const biowalletApi = chainConfigService.getBiowalletApi(config.id)
-      this.apiUrl = biowalletApi?.endpoint ?? ''
-      this.apiPath = biowalletApi?.path ?? config.id
+      this.baseUrl = chainConfigService.getBiowalletApi(config.id) ?? ''
     }
     return this.config
   }
@@ -54,12 +51,12 @@ export class BioforestChainService implements IChainService {
 
   async getBlockHeight(): Promise<bigint> {
     this.getConfig() // Ensure config is loaded
-    if (!this.apiUrl) {
+    if (!this.baseUrl) {
       return 0n
     }
 
     try {
-      const response = await fetch(`${this.apiUrl}/wallet/${this.apiPath}/lastblock`, {
+      const response = await fetch(`${this.baseUrl}/lastblock`, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
       })
@@ -91,7 +88,7 @@ export class BioforestChainService implements IChainService {
     const config = this.getConfig()
     const { decimals, symbol } = config
 
-    if (!this.apiUrl) {
+    if (!this.baseUrl) {
       // Return default fees - BioForest minimum is around 500 (0.000005 BFM)
       const defaultFee = Amount.fromRaw('1000', decimals, symbol) // 0.00001 BFM
       return {
@@ -103,7 +100,7 @@ export class BioforestChainService implements IChainService {
     }
 
     try {
-      const response = await fetch(`${this.apiUrl}/wallet/${this.apiPath}/blockAveFee`, {
+      const response = await fetch(`${this.baseUrl}/blockAveFee`, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
       })
@@ -150,7 +147,7 @@ export class BioforestChainService implements IChainService {
 
   async healthCheck(): Promise<HealthStatus> {
     this.getConfig() // Ensure config is loaded
-    if (!this.apiUrl) {
+    if (!this.baseUrl) {
       return {
         isHealthy: false,
         latency: 0,
@@ -163,7 +160,7 @@ export class BioforestChainService implements IChainService {
     const startTime = Date.now()
 
     try {
-      const response = await fetch(`${this.apiUrl}/wallet/${this.apiPath}/lastblock`, {
+      const response = await fetch(`${this.baseUrl}/lastblock`, {
         method: 'GET',
         headers: { 'Content-Type': 'application/json' },
       })

--- a/src/services/chain-config/__tests__/schema.test.ts
+++ b/src/services/chain-config/__tests__/schema.test.ts
@@ -44,13 +44,14 @@ describe('default-chains.json', () => {
     const versionedFile = VersionedChainConfigFileSchema.parse(parsedJson)
     const chains = versionedFile.chains
 
-    // 7 bioforest + 4 external (ethereum, binance, tron, bitcoin)
-    expect(chains).toHaveLength(11)
+    // 8 bioforest + 4 external (ethereum, binance, tron, bitcoin)
+    expect(chains).toHaveLength(12)
 
     const ids = chains.map(c => c.id).sort()
     expect(ids).toEqual([
       'bfchainv2',
       'bfmeta',
+      'bfmetav2',
       'binance',
       'bitcoin',
       'biwmeta',
@@ -68,7 +69,7 @@ describe('default-chains.json', () => {
     const tronChains = chains.filter(c => c.chainKind === 'tron')
     const bip39Chains = chains.filter(c => c.chainKind === 'bitcoin')
 
-    expect(bioforestChains).toHaveLength(7)
+    expect(bioforestChains).toHaveLength(8)
     expect(evmChains).toHaveLength(2)
     expect(tronChains).toHaveLength(1)
     expect(bip39Chains).toHaveLength(1)

--- a/src/services/chain-config/service.ts
+++ b/src/services/chain-config/service.ts
@@ -53,13 +53,12 @@ class ChainConfigService {
   }
 
   /**
-   * 获取 BioWallet API 配置 (匹配 biowallet-* 类型)
+   * 获取 BioWallet API endpoint (匹配 biowallet-* 类型)
+   * endpoint 已包含完整路径，如 https://walletapi.bfmeta.info/wallet/bfm
    */
-  getBiowalletApi(chainId: string): { endpoint: string; path: string } | null {
+  getBiowalletApi(chainId: string): string | null {
     const api = this.getApiByPattern(chainId, 'biowallet-*')
-    if (!api) return null
-    const path = (api.config?.path as string) ?? chainId
-    return { endpoint: api.endpoint, path }
+    return api?.endpoint ?? null
   }
 
   /**


### PR DESCRIPTION
## Summary
This fix addresses the critical bug where bioChain could only query the main asset but not other issued assets.

## Root Cause
The root cause was URL double-concatenation in the provider layer. The `getBiowalletApi()` returned `{ endpoint, path }` which was then being concatenated with the path again in the service layer.

## Changes
- `getBiowalletApi()` now returns full wallet API URL (e.g. `https://host/wallet/chainPath`)
- bioforest-sdk functions now accept single `baseUrl` parameter
- hooks/use-send.bioforest.ts updated to use new API signatures
- All service layer files updated to use `baseUrl` directly
- Test mocks updated for new return type
- schema.test.ts updated for new bfmetav2 chain count

## Breaking Change
`getBiowalletApi()` return type changed from `{ endpoint: string, path: string } | null` to `string | null`

## Testing
- All unit tests pass
- Type checking passes
- Integration tests with BFMetaV2 chain pass