### PR TITLE
fix(bioforest): use relative path for genesis block URLs

### DIFF
--- a/src/services/bioforest-sdk/index.ts
+++ b/src/services/bioforest-sdk/index.ts
@@ -99,12 +99,14 @@ function getGenesisBaseUrl(): string {
   if (genesisBaseUrl) {
     return genesisBaseUrl
   }
-  // Browser: use document.baseURI to get full HTTP URL
+  // Browser: use relative path from document.baseURI for subdirectory deployment support
+  // Using './configs/genesis' instead of '/configs/genesis' ensures correct resolution
+  // when deployed to subdirectories (e.g., GitHub Pages at /KeyApp/)
   if (typeof document !== 'undefined') {
-    return new URL('/configs/genesis', document.baseURI).href
+    return new URL('./configs/genesis', document.baseURI).href
   }
-  // Fallback
-  return '/configs/genesis'
+  // Fallback for non-browser environments
+  return './configs/genesis'
 }
 
 /**


### PR DESCRIPTION
## Summary
Use `./configs/genesis` instead of `/configs/genesis` to ensure correct URL resolution when deployed to subdirectories like GitHub Pages at `/KeyApp/`.

## Problem
When deployed to GitHub Pages at `https://bioforestchain.github.io/KeyApp/`, the absolute path `/configs/genesis` resolves to `https://bioforestchain.github.io/configs/genesis` (missing the `/KeyApp/` subdirectory), resulting in 404 errors.

## Solution
Changed from absolute path to relative path using `new URL('./configs/genesis', document.baseURI)` which correctly resolves to `https://bioforestchain.github.io/KeyApp/configs/genesis`.

Fixes #194