### PR TITLE
fix(forge): add missing bio_signMessage permission

### DIFF
--- a/miniapps/forge/manifest.json
+++ b/miniapps/forge/manifest.json
@@ -9,7 +9,7 @@
   "website": "https://forge.dweb.xin",
   "category": "exchange",
   "tags": ["兑换", "跨链桥", "DeFi"],
-  "permissions": ["bio_requestAccounts", "bio_selectAccount", "bio_createTransaction", "bio_signTransaction"],
+  "permissions": ["bio_requestAccounts", "bio_selectAccount", "bio_createTransaction", "bio_signTransaction", "bio_signMessage"],
   "chains": ["ethereum", "bfmeta"],
   "officialScore": 70,
   "communityScore": 85,


### PR DESCRIPTION
## Problem

The forge miniapp cannot complete the wallet connection flow because the `bio_signMessage` permission is not declared in its manifest.

### Root Cause

In `useForge.ts`, the hook calls `bio_signMessage` to sign the internal chain recharge message:

```typescript
const signResult = await window.bio.request<{ signature: string; publicKey: string }>({
  method: 'bio_signMessage',
  params: [{ message: messageToSign, address: internalAccount.address }],
})
```

However, `bio_signMessage` was not declared in `manifest.json`. The bridge validates permissions against the manifest and rejects undeclared methods with:

> "Permission not declared in manifest: bio_signMessage"

## Solution

Added `bio_signMessage` to the permissions array in `miniapps/forge/manifest.json`.

## Testing

- [x] All forge miniapp tests pass (38/38)
- [x] Typecheck passes