### PR TITLE
fix(ecosystem): avoid warning when source payload record does not exist

### DIFF
--- a/src/services/ecosystem/storage.ts
+++ b/src/services/ecosystem/storage.ts
@@ -90,6 +90,11 @@ export async function loadSourcePayload(url: string): Promise<SourcePayloadRecor
   const record = await requestToPromise(store.get(url))
   await transactionDone(tx)
 
+  // 记录不存在是正常情况，直接返回 null
+  if (record === undefined) {
+    return null
+  }
+
   const parsed = SourcePayloadRecordSchema.safeParse(record)
   if (!parsed.success) {
     console.warn('[EcosystemStorage] Invalid source payload record:', parsed.error.issues[0])


### PR DESCRIPTION
## Problem

首页启动时控制台输出多个警告：

```
[EcosystemStorage] Invalid source payload record: {expected: object, code: invalid_type, path: Array(0), message: Invalid input: expected object, received undefined}
```

## Root Cause

`loadSourcePayload` 函数在 IndexedDB 记录不存在时（返回 `undefined`），直接将其传给 Zod schema 验证，导致验证失败并打印警告。

但记录不存在是首次加载时的正常情况，不应该打印警告。

## Solution

在 schema 验证前检查 `record === undefined`，如果不存在则直接返回 `null`。

## Testing

修复前：
```
=== Console Warnings ===
1. [EcosystemStorage] Invalid source payload record: ...
2. [EcosystemStorage] Invalid source payload record: ...
...
Total: 0 errors, 6 warnings
```

修复后：
```
=== Console Errors ===
Total: 0 errors
```