### PR TITLE
feat(miniapps): add @biochain/key-ui and @biochain/key-utils dependencies

### DIFF
--- a/miniapps/forge/package.json
+++ b/miniapps/forge/package.json
@@ -28,6 +28,8 @@
   "dependencies": {
     "@base-ui/react": "^1.0.0",
     "@biochain/bio-sdk": "workspace:*",
+    "@biochain/key-ui": "workspace:*",
+    "@biochain/key-utils": "workspace:*",
     "@biochain/keyapp-sdk": "workspace:*",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-separator": "^1.1.8",

--- a/miniapps/teleport/package.json
+++ b/miniapps/teleport/package.json
@@ -28,6 +28,8 @@
   "dependencies": {
     "@base-ui/react": "^1.0.0",
     "@biochain/bio-sdk": "workspace:*",
+    "@biochain/key-ui": "workspace:*",
+    "@biochain/key-utils": "workspace:*",
     "@biochain/keyapp-sdk": "workspace:*",
     "@bnqkl/metabox-core": "0.5.2",
     "@bnqkl/wallet-typings": "0.23.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -354,6 +354,12 @@ importers:
       '@biochain/bio-sdk':
         specifier: workspace:*
         version: link:../../packages/bio-sdk
+      '@biochain/key-ui':
+        specifier: workspace:*
+        version: link:../../packages/key-ui
+      '@biochain/key-utils':
+        specifier: workspace:*
+        version: link:../../packages/key-utils
       '@biochain/keyapp-sdk':
         specifier: workspace:*
         version: link:../../packages/keyapp-sdk
@@ -487,6 +493,12 @@ importers:
       '@biochain/bio-sdk':
         specifier: workspace:*
         version: link:../../packages/bio-sdk
+      '@biochain/key-ui':
+        specifier: workspace:*
+        version: link:../../packages/key-ui
+      '@biochain/key-utils':
+        specifier: workspace:*
+        version: link:../../packages/key-utils
       '@biochain/keyapp-sdk':
         specifier: workspace:*
         version: link:../../packages/keyapp-sdk


### PR DESCRIPTION
## Summary

Add `@biochain/key-ui` and `@biochain/key-utils` dependencies to MiniApps (forge and teleport) to enable sharing of UI components.

## Changes

- `miniapps/forge/package.json`: Added key-ui and key-utils dependencies
- `miniapps/teleport/package.json`: Added key-ui and key-utils dependencies

## Verification

- [x] Typecheck passes for both miniapps
- [x] pnpm install successful

## Next Steps

MiniApps can now import components from `@biochain/key-ui`:

```tsx
import { Skeleton, Alert, GradientButton } from '@biochain/key-ui'
import { cn, formatAmount, truncateAddress } from '@biochain/key-utils'
```
