### PR TITLE
fix(ci): remove misleading outputs config from test:run task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -16,7 +16,7 @@
     "test:run": {
       "dependsOn": ["^build"],
       "inputs": ["src/**/*.ts", "src/**/*.tsx", "vitest.config.ts"],
-      "outputs": ["coverage/**"],
+      "outputs": [],
       "cache": true
     },
     "test:storybook": {


### PR DESCRIPTION
## Problem

Turbo was emitting warnings for multiple packages:

```
WARNING  no output files found for task @biochain/key-ui#test:run
WARNING  no output files found for task @biochain/key-utils#test:run
WARNING  no output files found for task @biochain/miniapp-forge#test:run
...
```

## Cause

The `test:run` task was configured with `outputs: ["coverage/**"]` but most packages don't generate coverage files during normal test runs.

## Solution

Changed `outputs` to `[]` since test results are ephemeral and not cached artifacts.

## Verification

```bash
pnpm turbo run test:run --filter=@biochain/key-ui
# No more warnings
```
