### PR TITLE
fix(ci): include packages/ and miniapps/ in change detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Detect changes
         id: changes
         run: |
-          CODE_CHANGED=$(git diff --name-only origin/${{ github.base_ref || 'main' }}...HEAD | grep -E '^src/|^e2e/' || true)
+          CODE_CHANGED=$(git diff --name-only origin/${{ github.base_ref || 'main' }}...HEAD | grep -E '^src/|^e2e/|^packages/|^miniapps/' || true)
           if [ -n "$CODE_CHANGED" ]; then
             echo "code=true" >> $GITHUB_OUTPUT
           else
@@ -86,6 +86,8 @@ jobs:
             code:
               - 'src/**'
               - 'e2e/**'
+              - 'packages/**'
+              - 'miniapps/**'
 
       - uses: oven-sh/setup-bun@v2
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Problem

During key-ui development, we discovered that CI change detection only monitored `src/` and `e2e/` directories. This meant:

1. Changes to `packages/key-ui` or `packages/key-utils` didn't trigger full CI runs
2. Changes to `miniapps/forge` or `miniapps/teleport` were also missed
3. This could lead to broken builds passing CI if only package files changed

## Solution

Extended change detection patterns in both CI paths:

**Self-hosted (ci-fast):**
```bash
# Before
grep -E '^src/|^e2e/'

# After  
grep -E '^src/|^e2e/|^packages/|^miniapps/'
```

**GitHub-hosted (ci-standard):**
```yaml
# Before
code:
  - 'src/**'
  - 'e2e/**'

# After
code:
  - 'src/**'
  - 'e2e/**'
  - 'packages/**'
  - 'miniapps/**'
```

## Impact

- Full CI (including E2E tests) will now run when any code in the monorepo changes
- Prevents false positives where package-only PRs skip important checks
