### PR TITLE
fix(turbo): improve cache invalidation with package.json and lockfile

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,27 +1,28 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["pnpm-lock.yaml"],
   "tasks": {
     "lint:run": {
       "dependsOn": ["eslint-plugin-file-component-constraints#build"],
-      "inputs": ["src/**/*.ts", "src/**/*.tsx", ".oxlintrc.json"],
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", ".oxlintrc.json", "package.json"],
       "outputs": [],
       "cache": true
     },
     "typecheck:run": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**/*.ts", "src/**/*.tsx", "tsconfig*.json"],
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", "tsconfig*.json", "package.json"],
       "outputs": [],
       "cache": true
     },
     "test:run": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**/*.ts", "src/**/*.tsx", "vitest.config.ts"],
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", "vitest.config.ts", "package.json"],
       "outputs": [],
       "cache": true
     },
     "test:storybook": {
       "dependsOn": ["^build"],
-      "inputs": ["src/**/*.ts", "src/**/*.tsx", "vitest.config.ts"],
+      "inputs": ["src/**/*.ts", "src/**/*.tsx", "vitest.config.ts", ".storybook/**", "package.json"],
       "outputs": [],
       "cache": true
     },


### PR DESCRIPTION
## Problem

During key-ui development, we encountered issues where:
1. Adding new dependencies to `package.json` didn't invalidate turbo cache
2. Stale typecheck results were used even after dependency changes
3. Storybook config changes didn't trigger re-runs

## Solution

### 1. Global lockfile dependency
```json
"globalDependencies": ["pnpm-lock.yaml"]
```
Any change to the lockfile now invalidates all caches globally.

### 2. Per-package dependency tracking
Added `package.json` to inputs for:
- `lint:run`
- `typecheck:run`
- `test:run`
- `test:storybook`

### 3. Storybook config tracking
Added `.storybook/**` to `test:storybook` inputs.

## Impact

| Scenario | Before | After |
|----------|--------|-------|
| Add workspace dependency | Cache hit (wrong) | Cache miss (correct) |
| Update pnpm-lock.yaml | Cache hit (wrong) | Cache miss (correct) |
| Modify .storybook/main.ts | Cache hit (wrong) | Cache miss (correct) |

## Verification

```bash
pnpm turbo run typecheck:run --filter=@biochain/key-ui
# Cached: 0 cached, 6 total (cache properly invalidated)
```
