### PR TITLE
fix(ci): preserve .turbo cache in self-hosted runners

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,13 +48,14 @@ jobs:
             git clone https://github.com/${{ github.repository }}.git .
           else
             # Self-hosted runners keep the workspace between runs; ensure clean checkout
+            # Preserve .turbo cache for incremental builds
             git reset --hard HEAD
-            git clean -fdx
+            git clean -fdx -e .turbo -e '**/.turbo'
           fi
           git fetch origin ${{ github.sha }} --depth=1 --tags
           git checkout -f ${{ github.sha }}
           git reset --hard HEAD
-          git clean -fdx
+          git clean -fdx -e .turbo -e '**/.turbo'
 
       - name: Determine channel
         id: channel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,14 @@ jobs:
             git clone --depth=1 https://github.com/${{ github.repository }}.git .
           else
             # Self-hosted runners keep the workspace between runs; ensure clean checkout
+            # Preserve .turbo cache for incremental builds
             git reset --hard HEAD
-            git clean -fdx
+            git clean -fdx -e .turbo -e '**/.turbo'
           fi
           git fetch origin ${{ github.event.pull_request.head.sha || github.sha }} --depth=1
           git checkout -f ${{ github.event.pull_request.head.sha || github.sha }}
           git reset --hard HEAD
-          git clean -fdx
+          git clean -fdx -e .turbo -e '**/.turbo'
 
       - name: Detect changes
         id: changes


### PR DESCRIPTION
## Problem
`git clean -fdx` was deleting `.turbo` cache directories on every CI run, causing full rebuilds instead of incremental builds.

## Solution
Add `-e .turbo -e '**/.turbo'` exclusions to `git clean` commands in both CI and CD workflows.

## Impact
- Faster CI/CD builds on self-hosted runners
- Turbo can now leverage cached build outputs across runs