### PR TITLE
fix: remove broken gradientButtonVariants export

### DIFF
--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -42,6 +42,3 @@ export { TimeDisplay, formatDate, formatDateTime, formatTime, toDate } from './t
 export { FormField } from './form-field'
 export { ErrorBoundary } from './error-boundary'
 export { CopyableText } from './copyable-text'
-
-// Legacy export for gradientButtonVariants (cva)
-export { gradientButtonVariants } from './gradient-button'


### PR DESCRIPTION
The gradientButtonVariants CVA export was removed from the source file in PR #221, but the re-export in index.ts was left behind, causing the build to fail.