### PR TITLE
fix(ci): preserve node_modules in self-hosted runners for faster builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,14 +48,14 @@ jobs:
             git clone https://github.com/${{ github.repository }}.git .
           else
             # Self-hosted runners keep the workspace between runs; ensure clean checkout
-            # Preserve .turbo cache for incremental builds
+            # Preserve .turbo cache and node_modules for faster builds
             git reset --hard HEAD
-            git clean -fdx -e .turbo -e '**/.turbo'
+            git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules'
           fi
           git fetch origin ${{ github.sha }} --depth=1 --tags
           git checkout -f ${{ github.sha }}
           git reset --hard HEAD
-          git clean -fdx -e .turbo -e '**/.turbo'
+          git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules'
 
       - name: Determine channel
         id: channel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ jobs:
             git clone --depth=1 https://github.com/${{ github.repository }}.git .
           else
             # Self-hosted runners keep the workspace between runs; ensure clean checkout
-            # Preserve .turbo cache for incremental builds
+            # Preserve .turbo cache and node_modules for faster builds
             git reset --hard HEAD
-            git clean -fdx -e .turbo -e '**/.turbo'
+            git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules'
           fi
           git fetch origin ${{ github.event.pull_request.head.sha || github.sha }} --depth=1
           git checkout -f ${{ github.event.pull_request.head.sha || github.sha }}
           git reset --hard HEAD
-          git clean -fdx -e .turbo -e '**/.turbo'
+          git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules'
 
       - name: Detect changes
         id: changes


### PR DESCRIPTION
Preserves `node_modules` directories across CI/CD runs on self-hosted runners to avoid re-downloading dependencies every time.

Changes:
- Added `-e node_modules -e '**/node_modules'` to `git clean` commands in both ci.yml and cd.yml

This should significantly speed up CI/CD runs on self-hosted runners.