### PR TITLE
fix(ci): preserve packages/*/dist to avoid rebuilding

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,14 +48,14 @@ jobs:
             git clone https://github.com/${{ github.repository }}.git .
           else
             # Self-hosted runners keep the workspace between runs; ensure clean checkout
-            # Preserve .turbo cache and node_modules for faster builds
+            # Preserve caches and build artifacts for faster builds
             git reset --hard HEAD
-            git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules'
+            git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules' -e 'packages/*/dist'
           fi
           git fetch origin ${{ github.sha }} --depth=1 --tags
           git checkout -f ${{ github.sha }}
           git reset --hard HEAD
-          git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules'
+          git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules' -e 'packages/*/dist'
 
       - name: Determine channel
         id: channel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,14 @@ jobs:
             git clone --depth=1 https://github.com/${{ github.repository }}.git .
           else
             # Self-hosted runners keep the workspace between runs; ensure clean checkout
-            # Preserve .turbo cache and node_modules for faster builds
+            # Preserve caches and build artifacts for faster builds
             git reset --hard HEAD
-            git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules'
+            git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules' -e 'packages/*/dist'
           fi
           git fetch origin ${{ github.event.pull_request.head.sha || github.sha }} --depth=1
           git checkout -f ${{ github.event.pull_request.head.sha || github.sha }}
           git reset --hard HEAD
-          git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules'
+          git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules' -e 'packages/*/dist'
 
       - name: Detect changes
         id: changes


### PR DESCRIPTION
Preserves `packages/*/dist` directories across CI/CD runs to avoid rebuilding package artifacts every time.

This should reduce the git checkout step from ~3 minutes to seconds.