### PR TITLE
fix(ci): also preserve miniapps/*/dist directories

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,12 +50,12 @@ jobs:
             # Self-hosted runners keep the workspace between runs; ensure clean checkout
             # Preserve caches and build artifacts for faster builds
             git reset --hard HEAD
-            git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules' -e 'packages/*/dist'
+            git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules' -e 'packages/*/dist' -e 'miniapps/*/dist'
           fi
           git fetch origin ${{ github.sha }} --depth=1 --tags
           git checkout -f ${{ github.sha }}
           git reset --hard HEAD
-          git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules' -e 'packages/*/dist'
+          git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules' -e 'packages/*/dist' -e 'miniapps/*/dist'
 
       - name: Determine channel
         id: channel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,12 @@ jobs:
             # Self-hosted runners keep the workspace between runs; ensure clean checkout
             # Preserve caches and build artifacts for faster builds
             git reset --hard HEAD
-            git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules' -e 'packages/*/dist'
+            git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules' -e 'packages/*/dist' -e 'miniapps/*/dist'
           fi
           git fetch origin ${{ github.event.pull_request.head.sha || github.sha }} --depth=1
           git checkout -f ${{ github.event.pull_request.head.sha || github.sha }}
           git reset --hard HEAD
-          git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules' -e 'packages/*/dist'
+          git clean -fdx -e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules' -e 'packages/*/dist' -e 'miniapps/*/dist'
 
       - name: Detect changes
         id: changes


### PR DESCRIPTION
Added `-e 'miniapps/*/dist'` to git clean commands to preserve miniapp build artifacts.