### PR TITLE
fix(transfer): navigate to home after transaction confirmed

### DIFF
--- a/src/stackflow/activities/sheets/TransferWalletLockJob.tsx
+++ b/src/stackflow/activities/sheets/TransferWalletLockJob.tsx
@@ -55,7 +55,7 @@ type Step = 'wallet_lock' | 'two_step_secret';
 
 function TransferWalletLockJobContent() {
   const { t } = useTranslation(["security", "transaction", "common"]);
-  const { pop, push } = useFlow();
+  const { pop, push, replace } = useFlow();
   const { title } = useActivityParams<TransferWalletLockJobParams>();
   const clipboard = useClipboard();
   const toast = useToast();
@@ -110,7 +110,12 @@ function TransferWalletLockJobContent() {
     return unsubscribe;
   }, [txHash, selectedChain, currentWallet?.address]);
 
-  // 上链成功后 5 秒倒计时自动关闭
+  // Navigate back to home (replace entire stack)
+  const goToHome = useCallback(() => {
+    replace('MainTabsActivity', {}, { animate: true });
+  }, [replace]);
+
+  // 上链成功后 5 秒倒计时自动关闭，返回首页
   useEffect(() => {
     if (txStatus !== 'confirmed') {
       setCountdown(null);
@@ -122,7 +127,7 @@ function TransferWalletLockJobContent() {
       setCountdown((prev) => {
         if (prev === null || prev <= 1) {
           clearInterval(timer);
-          pop();
+          goToHome();
           return null;
         }
         return prev - 1;
@@ -130,7 +135,7 @@ function TransferWalletLockJobContent() {
     }, 1000);
 
     return () => clearInterval(timer);
-  }, [txStatus, pop]);
+  }, [txStatus, goToHome]);
 
   // Get chain config for explorer URL
   const chainConfig = useMemo(() => {


### PR DESCRIPTION
## Summary
After transaction is confirmed and 5-second countdown completes, navigate back to home page instead of just popping one sheet.

## Changes
- Replace `pop()` with `replace('MainTabsActivity')` in TransferWalletLockJob
- Ensures user returns to home instead of staying on Send/Preview sheets

## Testing
- [x] pnpm typecheck passed