### PR TITLE
fix(stackflow): register TransferPreviewJob in activities object

### DIFF
--- a/src/stackflow/stackflow.ts
+++ b/src/stackflow/stackflow.ts
@@ -183,6 +183,7 @@ export const { Stack, useFlow, useStepFlow, activities } = stackflow({
     WalletListJob,
     SecurityWarningJob,
     TransferConfirmJob,
+    TransferPreviewJob,
     TransferWalletLockJob,
     FeeEditJob,
     ScannerJob,


### PR DESCRIPTION
## Summary
Fix critical bug: TransferPreviewJob was registered in routes but missing from activities object, causing 'activity does not exist' error when navigating to transaction preview.

## Error Fixed
```
Uncaught Error: the corresponding activity does not exist
    at validateEvents (chunk-A2IK3BTD.js)
    at handleProceed (index.tsx:233:5)
```

## Changes
- Added `TransferPreviewJob` to activities object in stackflow.ts

## Testing
- [x] pnpm typecheck passed