### PR TITLE
fix(e2e): update tests to use TransferPreviewJob selectors

### DIFF
--- a/e2e/bioforest-full-flow.spec.ts
+++ b/e2e/bioforest-full-flow.spec.ts
@@ -268,8 +268,8 @@ async function performTransfer(
   await continueBtn.click()
   await page.waitForTimeout(500)
 
-  // 点击确认转账
-  const confirmBtn = page.locator(`[data-testid="confirm-transfer-button"], button:has-text("${UI_TEXT.confirm.source}")`).first()
+  // 点击确认转账 (TransferPreviewJob)
+  const confirmBtn = page.locator(`[data-testid="confirm-preview-button"], button:has-text("${UI_TEXT.confirm.source}")`).first()
   await expect(confirmBtn).toBeVisible({ timeout: 5000 })
   await confirmBtn.click()
   await page.waitForTimeout(500)

--- a/e2e/bioforest-real-transfer.spec.ts
+++ b/e2e/bioforest-real-transfer.spec.ts
@@ -178,7 +178,7 @@ async function doTransfer(page: Page, toAddress: string, amount: string, needPay
   await expect(continueBtn).toBeEnabled({ timeout: 15000 })
   await continueBtn.click()
 
-  await page.locator('[data-testid="confirm-transfer-button"]').click()
+  await page.locator('[data-testid="confirm-preview-button"]').click()
 
   // 验证钱包锁
   const patternInput = page.locator('[data-testid="wallet-pattern-input"]')

--- a/e2e/bioforest-transfer.spec.ts
+++ b/e2e/bioforest-transfer.spec.ts
@@ -201,9 +201,9 @@ describeOrSkip('BioForest 转账测试', () => {
     await continueBtn.click()
     console.log('   ✅ 继续到确认页')
 
-    // 7. 确认转账
+    // 7. 确认转账（TransferPreviewJob）
     console.log('7. 确认转账...')
-    const confirmBtn = page.locator('[data-testid="confirm-transfer-button"]')
+    const confirmBtn = page.locator('[data-testid="confirm-preview-button"]')
     await expect(confirmBtn).toBeVisible({ timeout: 5000 })
     await confirmBtn.click()
     console.log('   ✅ 点击确认')

--- a/e2e/send-transaction.mock.spec.ts
+++ b/e2e/send-transaction.mock.spec.ts
@@ -344,14 +344,14 @@ test.describe('发送交易 - Job 弹窗流程', () => {
       await page.waitForTimeout(500)
       
       // 检查确认弹窗内容
-      const confirmBtn = page.locator('[data-testid="confirm-transfer-button"]')
-      const cancelBtn = page.locator('[data-testid="cancel-transfer-button"]')
+      const confirmBtn = page.locator('[data-testid="confirm-preview-button"]')
+      const cancelBtn = page.locator('[data-testid="cancel-preview-button"]')
       
       // 至少一个按钮应该可见（确认或取消）
       const hasConfirmUI = await confirmBtn.isVisible() || await cancelBtn.isVisible()
       
       if (hasConfirmUI) {
-        console.log('TransferConfirmJob opened successfully')
+        console.log('TransferPreviewJob opened successfully')
         
         // 截图
         await expect(page).toHaveScreenshot('send-confirm-job.png')
@@ -365,7 +365,7 @@ test.describe('发送交易 - Job 弹窗流程', () => {
           await expect(page.locator('[data-testid="send-continue-button"]')).toBeVisible()
         }
       } else {
-        console.log('TransferConfirmJob may not have opened - check mock configuration')
+        console.log('TransferPreviewJob may not have opened - check mock configuration')
       }
     } else {
       console.log('Continue button not enabled - mock service may not be configured correctly')
@@ -390,7 +390,7 @@ test.describe('发送交易 - Job 弹窗流程', () => {
       await continueBtn.click()
       await page.waitForTimeout(500)
       
-      const confirmBtn = page.locator('[data-testid="confirm-transfer-button"]')
+      const confirmBtn = page.locator('[data-testid="confirm-preview-button"]')
       
       if (await confirmBtn.isVisible()) {
         await confirmBtn.click()


### PR DESCRIPTION
## Summary
Update E2E tests to use new TransferPreviewJob selectors after switching from TransferConfirmJob.

## Changes
- Replace `confirm-transfer-button` with `confirm-preview-button`
- Replace `cancel-transfer-button` with `cancel-preview-button`
- Update comments to reflect new TransferPreviewJob flow

## Files Modified
- e2e/bioforest-full-flow.spec.ts
- e2e/bioforest-real-transfer.spec.ts
- e2e/bioforest-transfer.spec.ts
- e2e/send-transaction.mock.spec.ts