### PR TITLE
fix: use dynamic genesis beginEpochTime for BioChain transaction timestamps

### DIFF
--- a/src/components/common/time-display.tsx
+++ b/src/components/common/time-display.tsx
@@ -56,6 +56,7 @@ export function TimeDisplay({ value, format = 'relative', className }: TimeDispl
         day: '2-digit',
         hour: '2-digit',
         minute: '2-digit',
+        timeZoneName: 'short', // 显示时区信息以避免歧义
       });
       break;
     case 'time':
@@ -72,6 +73,7 @@ export function TimeDisplay({ value, format = 'relative', className }: TimeDispl
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
+    timeZoneName: 'short',
   });
 
   return (


### PR DESCRIPTION
## Problem
BioChain transaction timestamps were calculated using a hardcoded 2017-01-01 epoch, which is incorrect for chains like `biwmeta` and `bfmeta` that have different genesis times.

## Solution
- Read `beginEpochTime` from each chain's genesis block configuration
- Store as `epochMs` member variable in `BiowalletProvider`
- Use dynamic epoch in all timestamp calculations

## Additional Changes
- `TimeDisplay` component now includes timezone info (`timeZoneName: 'short'`) to avoid ambiguity

## Testing
- All 10 BiowalletProvider tests pass
- TypeScript compilation clean