### PR TITLE
feat: edit icon visibility + random wallet name from BIP39

### DIFF
--- a/src/i18n/locales/ar/onboarding.json
+++ b/src/i18n/locales/ar/onboarding.json
@@ -39,6 +39,7 @@
     "confirmWritten": "لقد كتبتها",
     "createFailed": "فشل في إنشاء المحفظة",
     "defaultWalletName": "المحفظة الرئيسية",
+    "walletSuffix": "محفظة",
     "enterWallet": "دخول المحفظة",
     "form": {
       "agreementPrefix": "لقد قرأت ووافقت على",

--- a/src/i18n/locales/en/onboarding.json
+++ b/src/i18n/locales/en/onboarding.json
@@ -41,6 +41,7 @@
     "confirmWritten": "I have written it down",
     "createFailed": "Failed to create wallet",
     "defaultWalletName": "Main Wallet",
+    "walletSuffix": "Wallet",
     "enterWallet": "Enter Wallet",
     "themeTitle": "Choose Card Theme",
     "themeSubtitle": "Select a theme color for your wallet card",

--- a/src/i18n/locales/zh-CN/onboarding.json
+++ b/src/i18n/locales/zh-CN/onboarding.json
@@ -30,6 +30,7 @@
     "wordIncorrect": "单词不正确",
     "complete": "完成创建",
     "defaultWalletName": "主钱包",
+    "walletSuffix": "钱包",
     "createFailed": "创建钱包失败",
     "themeTitle": "选择卡片主题",
     "themeSubtitle": "为您的钱包卡片选择一个主题色",

--- a/src/i18n/locales/zh-TW/onboarding.json
+++ b/src/i18n/locales/zh-TW/onboarding.json
@@ -39,6 +39,7 @@
     "confirmWritten": "我已抄寫完成",
     "createFailed": "建立錢包失敗",
     "defaultWalletName": "主錢包",
+    "walletSuffix": "錢包",
     "enterWallet": "進入錢包",
     "form": {
       "agreementPrefix": "我已閱讀並同意",

--- a/src/lib/wallet-utils.ts
+++ b/src/lib/wallet-utils.ts
@@ -1,0 +1,45 @@
+/**
+ * Wallet Utilities
+ * 
+ * Helper functions for wallet management
+ */
+
+import { wordlists } from 'bip39';
+
+/** Locale to BIP39 wordlist mapping */
+const LOCALE_WORDLIST_MAP: Record<string, string[] | undefined> = {
+    'zh-CN': wordlists.chinese_simplified,
+    'zh-TW': wordlists.chinese_traditional,
+    'ja': wordlists.japanese,
+    'ko': wordlists.korean,
+};
+
+/** 
+ * Locales that don't use spaces between words
+ * (Chinese, Japanese, Korean - CJK languages)
+ */
+const NO_SPACE_LOCALES = ['zh-CN', 'zh-TW', 'ja', 'ko'];
+
+/**
+ * Generate a random wallet name using BIP39 wordlist
+ * @param locale Current locale (e.g. 'zh-CN', 'en')
+ * @param suffix Localized suffix (e.g. '钱包', 'Wallet')
+ * @returns Generated wallet name (e.g. '爱钱包', 'Garden Wallet')
+ */
+export function generateWalletName(locale: string, suffix: string): string {
+    // Get wordlist for locale, fallback to English
+    const wordlist = LOCALE_WORDLIST_MAP[locale] ?? wordlists.english!;
+
+    // Pick a random word
+    const randomWord = wordlist[Math.floor(Math.random() * wordlist.length)];
+
+    // Capitalize first letter for non-CJK languages
+    const formattedWord = NO_SPACE_LOCALES.includes(locale)
+        ? randomWord
+        : randomWord.charAt(0).toUpperCase() + randomWord.slice(1);
+
+    // CJK languages don't use spaces
+    const useSpace = !NO_SPACE_LOCALES.includes(locale);
+
+    return useSpace ? `${formattedWord} ${suffix}` : `${formattedWord}${suffix}`;
+}

--- a/src/pages/my-card/index.tsx
+++ b/src/pages/my-card/index.tsx
@@ -148,7 +148,7 @@ export function MyCardPage() {
     }, [handleUsernameSave]);
 
     // Snapdom share hook
-    const { isProcessing: isDownloading, download: handleDownload, share: handleShare, canShare } = useSnapdomShare(
+    const { isProcessing: isDownloading, download: handleDownload, share: handleShare } = useSnapdomShare(
         cardRef,
         {
             filename: `my-card-${Date.now()}`,
@@ -197,7 +197,7 @@ export function MyCardPage() {
                         className="group mb-6 flex items-center gap-2 text-xl font-semibold"
                     >
                         <span>{displayName}</span>
-                        <Pencil className="size-4 text-muted-foreground opacity-0 group-hover:opacity-100" />
+                        <Pencil className="size-4 text-muted-foreground opacity-50 group-hover:opacity-100" />
                     </button>
                 )}
 

--- a/src/pages/wallet/create.tsx
+++ b/src/pages/wallet/create.tsx
@@ -17,8 +17,9 @@ import {
   IconCircleKey as KeyRound,
   IconCircleCheck as CheckCircle,
 } from '@tabler/icons-react';
-import { useChainConfigs, walletActions } from '@/stores';
+import { useChainConfigs, walletActions, useLanguage } from '@/stores';
 import { generateMnemonic } from '@/lib/crypto';
+import { generateWalletName } from '@/lib/wallet-utils';
 import { deriveWalletChainAddresses } from '@/services/chain-adapter';
 import { deriveThemeHue } from '@/hooks/useWalletTheme';
 import type { ChainConfig } from '@/services/chain-config';
@@ -31,6 +32,7 @@ export function WalletCreatePage() {
   const { goBack, navigate } = useNavigation();
   const { t } = useTranslation('onboarding');
   const chainConfigs = useChainConfigs();
+  const currentLanguage = useLanguage();
   const [step, setStep] = useState<Step>('pattern');
   const [patternKey, setPatternKey] = useState('');
   const [mnemonic] = useState<string[]>(() => {
@@ -122,7 +124,7 @@ export function WalletCreatePage() {
 
       const wallet = await walletActions.createWallet(
         {
-          name: t('create.defaultWalletName'),
+          name: generateWalletName(currentLanguage, t('create.walletSuffix')),
           keyType: 'mnemonic',
           address: primaryChain.address,
           chain: primaryChain.chain,
@@ -138,7 +140,7 @@ export function WalletCreatePage() {
       setCreatedWalletId(wallet.id);
       setStep('theme');
     } catch (error) {
-      
+
     } finally {
       setIsCreating(false);
     }


### PR DESCRIPTION
## Summary

### 功能一：编辑图标始终可见
- MyCardPage 用户名编辑图标现在始终可见 (opacity-50)
- hover 时变为全透明 (opacity-100)

### 功能二：随机钱包名称
- 使用 BIP39 wordlist 生成随机钱包名
- 多语言支持：zh-CN, zh-TW, ja, ko 使用本地词表
- CJK 语言无空格：`爱钱包`
- 其他语言有空格：`Apple Wallet`

## 文件变更
- `src/lib/wallet-utils.ts` - 新增 generateWalletName
- `src/pages/my-card/index.tsx` - 编辑图标可见性
- `src/pages/wallet/create.tsx` - 使用随机名称
- `src/i18n/locales/*/onboarding.json` - 添加 walletSuffix