### PR TITLE
fix: 接收页面卡片显示'向我转账'而非'添加联系人'

### DIFF
--- a/src/components/contact/contact-card.tsx
+++ b/src/components/contact/contact-card.tsx
@@ -4,6 +4,7 @@
  */
 
 import { QRCodeSVG } from 'qrcode.react';
+import { useTranslation } from 'react-i18next';
 import { ContactAvatar } from '@/components/common/contact-avatar';
 import { generateAvatarFromAddress } from '@/lib/avatar-codec';
 import { detectAddressFormat } from '@/lib/address-format';
@@ -59,11 +60,15 @@ export interface ContactCardProps {
   address?: string | undefined;
   addresses: ContactAddressInfo[];
   qrContent: string;
+  /** Optional custom caption below QR code. Defaults to 'Scan to add contact' */
+  caption?: string;
 }
 
-export function ContactCard({ name, avatar, address, addresses, qrContent }: ContactCardProps) {
+export function ContactCard({ name, avatar, address, addresses, qrContent, caption }: ContactCardProps) {
+  const { t } = useTranslation('common');
   const effectiveAddress = address || addresses[0]?.address;
   const effectiveAvatar = avatar || (effectiveAddress ? generateAvatarFromAddress(effectiveAddress) : undefined);
+  const displayCaption = caption ?? t('contactCard.scanToAdd');
   return (
     <div className="w-[320px] overflow-hidden rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-6 shadow-2xl">
       <div className="mb-6 flex items-center gap-4">
@@ -95,7 +100,7 @@ export function ContactCard({ name, avatar, address, addresses, qrContent }: Con
       </div>
 
       <div className="mt-4 text-center">
-        <p className="text-sm text-slate-400">扫码添加联系人</p>
+        <p className="text-sm text-slate-400">{displayCaption}</p>
       </div>
     </div>
   );

--- a/src/i18n/locales/ar/common.json
+++ b/src/i18n/locales/ar/common.json
@@ -252,6 +252,10 @@
   "publishDate": "Publish Date",
   "quantity": "[MISSING:ar] 数量",
   "receive": "استلام",
+  "contactCard": {
+    "scanToAdd": "امسح لإضافة جهة اتصال",
+    "transferToMe": "امسح للتحويل إليّ"
+  },
   "receivingGifts": "Receiving gifts",
   "refuse": "Refuse",
   "reject": "Reject",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -225,6 +225,10 @@
   "publishDate": "Publish Date",
   "quantity": "[MISSING:en] 数量",
   "receive": "Receive",
+  "contactCard": {
+    "scanToAdd": "Scan to add contact",
+    "transferToMe": "Scan to transfer to me"
+  },
   "receivingGifts": "Receiving gifts",
   "refuse": "Refuse",
   "reject": "Reject",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -4,6 +4,10 @@
   "confirm": "确认",
   "transfer": "转账",
   "receive": "收款",
+  "contactCard": {
+    "scanToAdd": "扫码添加联系人",
+    "transferToMe": "扫码向我转账"
+  },
   "paste": "粘贴",
   "addressPlaceholder": "输入或粘贴地址",
   "noAssets": "暂无资产",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -252,6 +252,10 @@
   "publishDate": "發行時間",
   "quantity": "數量",
   "receive": "收款",
+  "contactCard": {
+    "scanToAdd": "掃碼添加聯絡人",
+    "transferToMe": "掃碼向我轉帳"
+  },
   "receivingGifts": "資產接收",
   "refuse": "拒絕",
   "reject": "拒絕",

--- a/src/pages/receive/index.tsx
+++ b/src/pages/receive/index.tsx
@@ -140,6 +140,7 @@ export function ReceivePage() {
             avatar={profile.avatar}
             addresses={[{ address, label: selectedChainName }]}
             qrContent={qrContent}
+            caption={t('common:contactCard.transferToMe')}
           />
         </div>
 


### PR DESCRIPTION
## Summary

### 变更
- ContactCard 添加可选 `caption` prop
- ReceivePage 传递 `contactCard.transferToMe` 作为 caption
- 其他使用 ContactCard 的地方保持默认 `contactCard.scanToAdd`

### i18n 翻译
| Locale | scanToAdd | transferToMe |
|--------|-----------|--------------|
| zh-CN | 扫码添加联系人 | 扫码向我转账 |
| en | Scan to add contact | Scan to transfer to me |
| zh-TW | 掃碼添加聯絡人 | 掃碼向我轉帳 |
| ar | امسح لإضافة جهة اتصال | امسح للتحويل إليّ |

### 测试
✅ 13/13 receive tests pass