### PR TITLE
fix(build): key-utils as pure TS package + fix remote miniapp icon URLs

### DIFF
--- a/packages/key-utils/package.json
+++ b/packages/key-utils/package.json
@@ -3,23 +3,21 @@
   "version": "0.1.0",
   "description": "Utility functions for KeyApp UI components",
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./src/index.ts",
+  "module": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
     },
     "./*": {
-      "import": "./dist/*.js",
-      "require": "./dist/*.cjs",
-      "types": "./dist/*.d.ts"
+      "import": "./src/*.ts",
+      "types": "./src/*.ts"
     }
   },
   "files": [
-    "dist"
+    "src"
   ],
   "scripts": {
     "build": "vite build",

--- a/scripts/vite-plugin-miniapps.ts
+++ b/scripts/vite-plugin-miniapps.ts
@@ -305,12 +305,13 @@ function scanRemoteMiniappsForBuild(miniappsPath: string): Array<MiniappManifest
 
     try {
       const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8')) as MiniappManifest;
+      const baseUrl = `./${entry.name}/`;
       remoteApps.push({
         ...manifest,
         dirName: entry.name,
-        url: `./${entry.name}/`,
-        icon: `./${entry.name}/${manifest.icon}`,
-        screenshots: manifest.screenshots?.map((s) => `./${entry.name}/${s}`) ?? [],
+        url: baseUrl,
+        icon: manifest.icon.startsWith('http') ? manifest.icon : new URL(manifest.icon, baseUrl).href,
+        screenshots: manifest.screenshots?.map((s) => (s.startsWith('http') ? s : new URL(s, baseUrl).href)) ?? [],
       });
     } catch {
       console.warn(`[miniapps] ${entry.name}: invalid remote manifest.json, skipping`);


### PR DESCRIPTION
## Summary

- 修复 `@biochain/key-ui` typecheck 失败问题
- 修复远程 miniapp icon URL 拼接 bug

## Changes

| 文件 | 改动 |
|------|------|
| `packages/key-utils/package.json` | 改为直接导出 `src/*.ts`（纯 TS 包，无需 build） |
| `scripts/vite-plugin-miniapps.ts` | 使用 `new URL()` 处理相对路径，保留绝对 URL |

## Why

1. `key-utils` 是纯工具函数包，不需要编译，直接导出源码即可
2. 远程 miniapp 的 `icon` 可能是绝对 URL（如 `https://...`），之前的字符串拼接会生成错误路径如 `./rwa-hub/https://...`