### PR TITLE
fix(wujie): simplify URL rewrite with direct new URL(url, placeholder)

### DIFF
--- a/src/services/miniapp-runtime/container/wujie-container.ts
+++ b/src/services/miniapp-runtime/container/wujie-container.ts
@@ -61,26 +61,17 @@ function rewriteHtmlAbsolutePaths(html: string, baseUrl: string): string {
   return doc.documentElement.outerHTML;
 }
 
-const PLACEHOLDER_ORIGIN = 'https://placeholder.local';
+const PLACEHOLDER_ORIGIN = 'https://placeholder.local/';
 
 function createAbsolutePathRewriter(baseUrl: string) {
-  const parsedUrl = new URL(baseUrl);
-  const targetBase = parsedUrl.origin + parsedUrl.pathname;
+  const targetBase = new URL(baseUrl).href;
 
   return {
     fetch: (input: RequestInfo | URL, init?: RequestInit) => {
       const req = new Request(input, init);
-      const parsedReqUrl = new URL(req.url);
-
-      if (parsedReqUrl.origin === window.location.origin) {
-        const normalized = new URL(
-          parsedReqUrl.pathname + parsedReqUrl.search + parsedReqUrl.hash,
-          PLACEHOLDER_ORIGIN + '/',
-        );
-        const rewrittenUrl = normalized.href.replace(PLACEHOLDER_ORIGIN + '/', targetBase);
-        return window.fetch(rewrittenUrl, init);
-      }
-      return window.fetch(req);
+      const normalized = new URL(req.url, PLACEHOLDER_ORIGIN);
+      const rewrittenUrl = normalized.href.replace(PLACEHOLDER_ORIGIN, targetBase);
+      return window.fetch(rewrittenUrl, init);
     },
     plugins: [
       {


### PR DESCRIPTION
## Problem

Previous fix was overly complex, manually extracting pathname/search/hash.

## Fix

Simplified to just:
```typescript
const normalized = new URL(req.url, PLACEHOLDER_ORIGIN);
const rewrittenUrl = normalized.href.replace(PLACEHOLDER_ORIGIN, targetBase);
```

**Benefits:**
- If URL has its own host (e.g., CDN), it's preserved automatically
- No manual parsing of pathname/search/hash
- 5 lines vs 14 lines