### PR TITLE
fix(wujie): preserve request headers in fetch interceptor

### DIFF
--- a/src/services/miniapp-runtime/container/wujie-container.ts
+++ b/src/services/miniapp-runtime/container/wujie-container.ts
@@ -77,7 +77,9 @@ function createAbsolutePathRewriter(baseUrl: string) {
       }
       const rewrittenUrl = normalized.href.replace(PLACEHOLDER_ORIGIN, targetBaseHref);
 
-      return window.fetch(rewrittenUrl, init);
+      // 使用原始 Request 对象的完整配置（包括 headers），仅替换 URL
+      // 这确保 tRPC 的 trpc-accept 等自定义头不会丢失
+      return window.fetch(new Request(rewrittenUrl, req));
     },
     plugins: [
       {


### PR DESCRIPTION
## Summary

- Fix wujie fetch interceptor losing custom headers (like `trpc-accept`) when rewriting URLs
- This caused tRPC streaming responses to fail in wujie containers while working correctly in standalone mode

## Root Cause

The fetch interceptor was using `window.fetch(rewrittenUrl, init)` where `init` might not contain the complete headers from the original `Request` object. When tRPC sends requests with `trpc-accept: application/jsonl`, this header was lost, causing the server to return traditional JSON instead of streaming JSONL.

## Fix

Changed from:
```typescript
return window.fetch(rewrittenUrl, init);
```

To:
```typescript
return window.fetch(new Request(rewrittenUrl, req));
```

This preserves the original request's complete configuration including all headers.