### PR TITLE
fix: enforce i18n key usage and fill missing translations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           
           if [ "${{ steps.changes.outputs.code }}" == "true" ]; then
             # 运行静态检查
+            pnpm i18n:run
             pnpm turbo run lint:run typecheck:run build i18n:run theme:run test:run test:storybook e2e:audit
             
             # 使用 e2e:runner 分片运行 E2E 测试，避免单次全部运行
@@ -56,6 +57,7 @@ jobs:
             pnpm e2e:runner --all -j 2
             pnpm e2e:ci:real
           else
+            pnpm i18n:run
             pnpm turbo run lint:run typecheck:run build i18n:run theme:run test:run test:storybook
           fi
           
@@ -121,8 +123,10 @@ jobs:
         run: |
           if [ "${{ steps.changes.outputs.code }}" == "true" ]; then
             # 运行所有测试：lint + 单元测试 + Storybook 组件测试 + E2E 测试 + 主题检查
+            pnpm i18n:run
             pnpm turbo run lint:run typecheck:run build i18n:run theme:run test:run test:storybook e2e:audit e2e:ci e2e:ci:mock e2e:ci:real
           else
+            pnpm i18n:run
             pnpm turbo run lint:run typecheck:run build i18n:run theme:run test:run test:storybook
           fi
 

--- a/src/i18n/locales/ar/common.json
+++ b/src/i18n/locales/ar/common.json
@@ -85,9 +85,13 @@
     "useExplorerHint": "This chain does not support direct history query, please use the explorer",
     "viewOnExplorer": "View on {{name}}"
   },
-  "sign": {
+  "beta": "نسخة تجريبية",
+  "signSymbol": {
     "plus": "+",
     "minus": "-"
+  },
+  "walletLock": {
+    "error": "فشل التحقق من قفل المحفظة"
   },
   "addressPlaceholder": "أدخل أو الصق العنوان",
   "advancedEncryptionTechnologyDigitalWealthIsMoreSecure": "Advanced encryption technology &lt;br /&gt; Digital wealth is more secure",
@@ -510,9 +514,11 @@
       "description": "سلاسل متوافقة مع آلة إيثريوم الافتراضية"
     },
     "bitcoin": {
+      "name": "بيتكوين",
       "description": "شبكة Bitcoin"
     },
     "tron": {
+      "name": "ترون",
       "description": "شبكة Tron"
     },
     "custom": {

--- a/src/i18n/locales/ar/error.json
+++ b/src/i18n/locales/ar/error.json
@@ -19,11 +19,14 @@
     "enterAmount": "Please enter amount",
     "enterValidAmount": "Please enter a valid amount",
     "exceedsBalance": "Amount exceeds balance",
+    "selectAsset": "يرجى اختيار أصل",
     "enterReceiverAddress": "يرجى إدخال عنوان المستلم",
-    "invalidAddress": "تنسيق العنوان غير صالح"
+    "invalidAddress": "تنسيق العنوان غير صالح",
+    "unsupportedChainType": "نوع سلسلة غير مدعوم"
   },
   "transaction": {
     "failed": "Transaction failed, please try again later",
+    "transactionFailed": "فشلت المعاملة، يرجى المحاولة لاحقاً",
     "burnFailed": "Burn failed, please try again later",
     "chainNotSupported": "This chain does not support full transaction flow",
     "chainNotSupportedWithId": "This chain does not support full transaction flow: {{chainId}}",
@@ -35,10 +38,15 @@
     "issuerAddressNotFound": "Unable to get asset issuer address",
     "issuerAddressNotReady": "Asset issuer address not ready",
     "insufficientGas": "رسوم الغاز غير كافية",
+    "invalidAmount": "مبلغ غير صالح",
+    "paramsIncomplete": "معلمات المعاملة غير مكتملة",
     "retryLater": "فشلت المعاملة، يرجى المحاولة لاحقاً",
     "transferFailed": "فشل التحويل",
     "securityPasswordWrong": "كلمة مرور الأمان غير صحيحة",
     "unknownError": "خطأ غير معروف"
+  },
+  "burn": {
+    "bioforestOnly": "الحرق مدعوم فقط على BioForest"
   },
   "crypto": {
     "keyDerivationFailed": "فشل اشتقاق المفتاح",

--- a/src/i18n/locales/ar/guide.json
+++ b/src/i18n/locales/ar/guide.json
@@ -4,6 +4,7 @@
     "next": "التالي",
     "getStarted": "ابدأ الآن",
     "haveWallet": "لدي محفظة",
+    "migrateFromMpay": "الترحيل من MPay",
     "goToSlide": "انتقل إلى الشريحة {{number}}",
     "slides": {
       "transfer": {

--- a/src/i18n/locales/ar/transaction.json
+++ b/src/i18n/locales/ar/transaction.json
@@ -4,6 +4,11 @@
   "amountShouldBe_{min}-{max}-{assettype}": "Amount should be -",
   "approve": "Approve",
   "balance_:": "Balance:",
+  "assetSelector": {
+    "selectAsset": "اختر الأصل",
+    "balance": "الرصيد",
+    "noAssets": "لا توجد أصول"
+  },
   "bioforestChainFeeToLow": "If the miner fee is too low, it will affect the transaction on-chain.",
   "bioforestChainTransactionTypeAcceptAnyAssetExchange": "Accept Any Asset Exchange",
   "bioforestChainTransactionTypeAcceptAnyAssetGift": "Accept Any Asset Gift",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -425,9 +425,13 @@
     "openExplorer": "Open {{name}} Explorer",
     "viewOnExplorer": "View on {{name}}"
   },
-  "sign": {
+  "beta": "Beta",
+  "signSymbol": {
     "plus": "+",
     "minus": "-"
+  },
+  "walletLock": {
+    "error": "Wallet lock verification failed"
   },
   "tabs": {
     "assets": "Assets",
@@ -510,9 +514,11 @@
       "description": "Ethereum Virtual Machine compatible chains"
     },
     "bitcoin": {
+      "name": "Bitcoin",
       "description": "Bitcoin network"
     },
     "tron": {
+      "name": "TRON",
       "description": "Tron network"
     },
     "custom": {

--- a/src/i18n/locales/en/error.json
+++ b/src/i18n/locales/en/error.json
@@ -19,11 +19,14 @@
     "enterAmount": "Please enter amount",
     "enterValidAmount": "Please enter a valid amount",
     "exceedsBalance": "Amount exceeds balance",
+    "selectAsset": "Please select an asset",
     "enterReceiverAddress": "Please enter recipient address",
-    "invalidAddress": "Invalid address format"
+    "invalidAddress": "Invalid address format",
+    "unsupportedChainType": "Unsupported chain type"
   },
   "transaction": {
     "failed": "Transaction failed, please try again later",
+    "transactionFailed": "Transaction failed, please try again later",
     "burnFailed": "Burn failed, please try again later",
     "chainNotSupported": "This chain does not support full transaction flow",
     "chainNotSupportedWithId": "This chain does not support full transaction flow: {{chainId}}",
@@ -35,10 +38,15 @@
     "issuerAddressNotFound": "Unable to get asset issuer address",
     "issuerAddressNotReady": "Asset issuer address not ready",
     "insufficientGas": "Insufficient gas fee",
+    "invalidAmount": "Invalid amount",
+    "paramsIncomplete": "Transaction parameters incomplete",
     "retryLater": "Transaction failed, please try again later",
     "transferFailed": "Transfer failed",
     "securityPasswordWrong": "Security password incorrect",
     "unknownError": "Unknown error"
+  },
+  "burn": {
+    "bioforestOnly": "Burn is only supported on BioForest"
   },
   "crypto": {
     "keyDerivationFailed": "Key derivation failed",

--- a/src/i18n/locales/en/guide.json
+++ b/src/i18n/locales/en/guide.json
@@ -4,6 +4,7 @@
     "next": "Next",
     "getStarted": "Get Started",
     "haveWallet": "I have a wallet",
+    "migrateFromMpay": "Migrate from MPay",
     "goToSlide": "Go to slide {{number}}",
     "slides": {
       "transfer": {

--- a/src/i18n/locales/en/transaction.json
+++ b/src/i18n/locales/en/transaction.json
@@ -4,6 +4,11 @@
   "amountShouldBe_{min}-{max}-{assettype}": "Amount should be -",
   "approve": "Approve",
   "balance_:": "Balance:",
+  "assetSelector": {
+    "selectAsset": "Select asset",
+    "balance": "Balance",
+    "noAssets": "No assets"
+  },
   "bioforestChainFeeToLow": "If the miner fee is too low, it will affect the transaction on-chain.",
   "bioforestChainTransactionTypeAcceptAnyAssetExchange": "Accept Any Asset Exchange",
   "bioforestChainTransactionTypeAcceptAnyAssetGift": "Accept Any Asset Gift",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -425,9 +425,13 @@
     "openExplorer": "打开 {{name}} 浏览器",
     "viewOnExplorer": "在 {{name}} 浏览器中查看"
   },
-  "sign": {
+  "beta": "测试版",
+  "signSymbol": {
     "plus": "+",
     "minus": "-"
+  },
+  "walletLock": {
+    "error": "钱包锁验证失败"
   },
   "tabs": {
     "assets": "资产",
@@ -510,9 +514,11 @@
       "description": "以太坊虚拟机兼容链"
     },
     "bitcoin": {
+      "name": "比特币",
       "description": "Bitcoin 网络"
     },
     "tron": {
+      "name": "波场",
       "description": "Tron 网络"
     },
     "custom": {

--- a/src/i18n/locales/zh-CN/error.json
+++ b/src/i18n/locales/zh-CN/error.json
@@ -19,11 +19,14 @@
     "enterAmount": "请输入金额",
     "enterValidAmount": "请输入有效金额",
     "exceedsBalance": "销毁数量不能大于余额",
+    "selectAsset": "请选择资产",
     "enterReceiverAddress": "请输入收款地址",
-    "invalidAddress": "无效的地址格式"
+    "invalidAddress": "无效的地址格式",
+    "unsupportedChainType": "不支持的链类型"
   },
   "transaction": {
     "failed": "交易失败，请稍后重试",
+    "transactionFailed": "交易失败，请稍后重试",
     "burnFailed": "销毁失败，请稍后重试",
     "chainNotSupported": "该链不支持完整交易流程",
     "chainNotSupportedWithId": "该链不支持完整交易流程: {{chainId}}",
@@ -35,10 +38,15 @@
     "issuerAddressNotFound": "无法获取资产发行地址",
     "issuerAddressNotReady": "资产发行地址未获取",
     "insufficientGas": "手续费不足",
+    "invalidAmount": "金额无效",
+    "paramsIncomplete": "交易参数不完整",
     "retryLater": "交易失败，请稍后重试",
     "transferFailed": "转账失败",
     "securityPasswordWrong": "安全密码错误",
     "unknownError": "未知错误"
+  },
+  "burn": {
+    "bioforestOnly": "销毁仅支持 BioForest 链"
   },
   "crypto": {
     "keyDerivationFailed": "密钥派生失败",

--- a/src/i18n/locales/zh-CN/guide.json
+++ b/src/i18n/locales/zh-CN/guide.json
@@ -4,6 +4,7 @@
     "next": "下一步",
     "getStarted": "开始使用",
     "haveWallet": "我有钱包",
+    "migrateFromMpay": "从 MPay 迁移",
     "goToSlide": "跳转到第 {{number}} 页",
     "slides": {
       "transfer": {

--- a/src/i18n/locales/zh-CN/transaction.json
+++ b/src/i18n/locales/zh-CN/transaction.json
@@ -10,6 +10,11 @@
     "yesterday": "昨天",
     "daysAgo": "{{days}}天前"
   },
+  "assetSelector": {
+    "selectAsset": "选择资产",
+    "balance": "余额",
+    "noAssets": "暂无资产"
+  },
   "receivePage": {
     "title": "收款",
     "scanQrCode": "扫描二维码向此地址转账",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -85,9 +85,13 @@
     "useExplorerHint": "此鏈不支援直接查詢交易歷史，請使用瀏覽器查看",
     "viewOnExplorer": "在 {{name}} 瀏覽器中查看"
   },
-  "sign": {
+  "beta": "測試版",
+  "signSymbol": {
     "plus": "+",
     "minus": "-"
+  },
+  "walletLock": {
+    "error": "錢包鎖驗證失敗"
   },
   "addressPlaceholder": "輸入或貼上地址",
   "advancedEncryptionTechnologyDigitalWealthIsMoreSecure": "先進的加密技術 &lt;br /&gt; 數字財富更安全",
@@ -510,9 +514,11 @@
       "description": "以太坊虛擬機兼容鏈"
     },
     "bitcoin": {
+      "name": "比特幣",
       "description": "Bitcoin 網絡"
     },
     "tron": {
+      "name": "波場",
       "description": "Tron 網絡"
     },
     "custom": {

--- a/src/i18n/locales/zh-TW/error.json
+++ b/src/i18n/locales/zh-TW/error.json
@@ -19,11 +19,14 @@
     "enterAmount": "請輸入金額",
     "enterValidAmount": "請輸入有效金額",
     "exceedsBalance": "銷毀數量不能大於餘額",
+    "selectAsset": "請選擇資產",
     "enterReceiverAddress": "請輸入收款地址",
-    "invalidAddress": "無效的地址格式"
+    "invalidAddress": "無效的地址格式",
+    "unsupportedChainType": "不支援的鏈類型"
   },
   "transaction": {
     "failed": "交易失敗，請稍後重試",
+    "transactionFailed": "交易失敗，請稍後重試",
     "burnFailed": "銷毀失敗，請稍後重試",
     "chainNotSupported": "該鏈不支持完整交易流程",
     "chainNotSupportedWithId": "該鏈不支持完整交易流程: {{chainId}}",
@@ -35,10 +38,15 @@
     "issuerAddressNotFound": "無法獲取資產發行地址",
     "issuerAddressNotReady": "資產發行地址未獲取",
     "insufficientGas": "手續費不足",
+    "invalidAmount": "金額無效",
+    "paramsIncomplete": "交易參數不完整",
     "retryLater": "交易失敗，請稍後重試",
     "transferFailed": "轉帳失敗",
     "securityPasswordWrong": "安全密碼錯誤",
     "unknownError": "未知錯誤"
+  },
+  "burn": {
+    "bioforestOnly": "銷毀僅支援 BioForest 鏈"
   },
   "crypto": {
     "keyDerivationFailed": "密鑰派生失敗",

--- a/src/i18n/locales/zh-TW/guide.json
+++ b/src/i18n/locales/zh-TW/guide.json
@@ -4,6 +4,7 @@
     "next": "下一步",
     "getStarted": "開始使用",
     "haveWallet": "我有錢包",
+    "migrateFromMpay": "從 MPay 遷移",
     "goToSlide": "跳轉到第 {{number}} 頁",
     "slides": {
       "transfer": {

--- a/src/i18n/locales/zh-TW/transaction.json
+++ b/src/i18n/locales/zh-TW/transaction.json
@@ -4,6 +4,11 @@
   "amountShouldBe_{min}-{max}-{assettype}": "數量應在 - 之間",
   "approve": "授權",
   "balance_:": "餘額:",
+  "assetSelector": {
+    "selectAsset": "選擇資產",
+    "balance": "餘額",
+    "noAssets": "暫無資產"
+  },
   "bioforestChainFeeToLow": "如果礦工費過低，將影響交易上鏈。",
   "bioforestChainTransactionTypeAcceptAnyAssetExchange": "接受任意資產交換",
   "bioforestChainTransactionTypeAcceptAnyAssetGift": "接受任意資產贈送",

--- a/src/pages/address-transactions/index.tsx
+++ b/src/pages/address-transactions/index.tsx
@@ -29,7 +29,7 @@ function TransactionItem({ tx, address }: { tx: Transaction; address: string }) 
   const value = primaryAsset ? primaryAsset.value : '0'
   const symbol = primaryAsset ? primaryAsset.symbol : ''
   const decimals = primaryAsset ? primaryAsset.decimals : 0
-  const sign = isOutgoing ? t('sign.minus') : t('sign.plus')
+  const sign = isOutgoing ? t('signSymbol.minus') : t('signSymbol.plus')
   const directionLabel = isOutgoing ? t('addressLookup.toLabel') : t('addressLookup.fromLabel')
 
   return (


### PR DESCRIPTION
Closes #295

## Summary
- strengthen i18n check to validate keys referenced in source (ignores comments)
- run root i18n check in CI before turbo tasks
- fill missing chainKind names and other missing translations across locales
- align address transactions sign labels to common.signSymbol

## Testing
- pnpm i18n:run
- pnpm agent review verify