### PR TITLE
fix: force fetch tags in cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,10 +48,10 @@ jobs:
           EXCLUDES="-e .turbo -e '**/.turbo' -e node_modules -e '**/node_modules' -e 'packages/*/dist' -e 'miniapps/*/dist'"
           if [ ! -d ".git" ]; then
             git clone --depth=1 https://github.com/${{ github.repository }}.git .
-            git fetch origin $COMMIT --depth=1 --tags
+            git fetch origin $COMMIT --depth=1 --tags --force
             git checkout -f $COMMIT
           else
-            git fetch origin $COMMIT --depth=1 --tags
+            git fetch origin $COMMIT --depth=1 --tags --force
             git checkout -f $COMMIT
             eval "git clean -fdx $EXCLUDES"
           fi


### PR DESCRIPTION
Closes #303\n\n- force-fetch tags on self-hosted checkout to avoid tag clobber errors