### PR TITLE
fix: align pnpm version in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ concurrency:
 
 env:
   NODE_VERSION: '24'
-  PNPM_VERSION: '10'
+  PNPM_VERSION: '10.28.0'
 
 jobs:
   # ==================== Self-hosted 快速构建 (无 action 下载) ====================


### PR DESCRIPTION
Closes #305\n\n- align PNPM_VERSION with packageManager to fix build-standard