### PR TITLE
fix(cd): upload release files only

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -412,14 +412,22 @@ jobs:
           retry_wait_seconds: 30
           retry_on: error
           command: |
+            release_files=()
+            while IFS= read -r -d '' file; do
+              release_files+=("$file")
+            done < <(find release -type f -print0)
+            if [ "${#release_files[@]}" -eq 0 ]; then
+              echo "No release assets found"
+              exit 1
+            fi
             gh release create "$TAG_NAME" \
               --title "$RELEASE_TITLE" \
               --notes "$RELEASE_NOTES" \
               ${{ steps.channel.outputs.channel == 'beta' && '--prerelease' || '' }} \
               --target ${{ github.sha }} \
-              release/* \
+              "${release_files[@]}" \
               2>/dev/null || \
-            gh release upload "$TAG_NAME" release/* --clobber
+            gh release upload "$TAG_NAME" "${release_files[@]}" --clobber
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ steps.channel.outputs.channel == 'stable' && format('v{0}', steps.version.outputs.version) || 'beta' }}
@@ -916,14 +924,22 @@ jobs:
           retry_wait_seconds: 30
           retry_on: error
           command: |
+            release_files=()
+            while IFS= read -r -d '' file; do
+              release_files+=("$file")
+            done < <(find release -type f -print0)
+            if [ "${#release_files[@]}" -eq 0 ]; then
+              echo "No release assets found"
+              exit 1
+            fi
             gh release create "$TAG_NAME" \
               --title "$RELEASE_TITLE" \
               --notes "$RELEASE_NOTES" \
               ${{ needs.build-standard.outputs.channel == 'beta' && '--prerelease' || '' }} \
               --target ${{ github.sha }} \
-              release/* \
+              "${release_files[@]}" \
               2>/dev/null || \
-            gh release upload "$TAG_NAME" release/* --clobber
+            gh release upload "$TAG_NAME" "${release_files[@]}" --clobber
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ needs.build-standard.outputs.channel == 'stable' && format('v{0}', needs.build-standard.outputs.version) || 'beta' }}


### PR DESCRIPTION
Closes #319

## Goal
Fix stable CD release creation failing on directories in release assets.

## Changes
- Filter release assets to files only before gh release create/upload in cd.yml.

## Notes
- Avoids GH CLI failure when release contains folders like release/logos.
