### PR TITLE
fix(ecosystem): resolve race conditions and UI issues in miniapp launch

### DIFF
--- a/packages/ecosystem-native/react/WindowStackWrapper.tsx
+++ b/packages/ecosystem-native/react/WindowStackWrapper.tsx
@@ -1,0 +1,62 @@
+/**
+ * React wrapper for ecosystem-window-stack Web Component
+ */
+
+import type { MiniappTargetDesktop } from '../src/components/types';
+// Import to register the custom element
+import '../src/components/window-stack';
+
+export interface WindowStackWrapperProps {
+  /** Which desktop this stack belongs to ('mine' or 'stack') */
+  desktop: MiniappTargetDesktop;
+  /** Additional class name */
+  className?: string;
+  /** Additional styles */
+  style?: React.CSSProperties;
+}
+
+/**
+ * React wrapper for the native WindowStack Web Component
+ *
+ * This component wraps the ecosystem-window-stack custom element.
+ * The WindowStack auto-registers with windowStackManager in its connectedCallback,
+ * so no useEffect is needed here.
+ *
+ * @example
+ * ```tsx
+ * // In your desktop page component
+ * <WindowStackWrapper desktop="mine" />
+ * ```
+ *
+ * Then in the miniapp runtime:
+ * ```ts
+ * import { windowStackManager } from '@biochain/ecosystem-native';
+ *
+ * // Synchronously get or create a slot
+ * const slot = windowStackManager.getOrCreateSlot('mine', appId);
+ * ```
+ */
+export function WindowStackWrapper({ desktop, className, style }: WindowStackWrapperProps) {
+  return (
+    <ecosystem-window-stack
+      desktop={desktop}
+      class={className}
+      style={style}
+    />
+  );
+}
+
+// Extend JSX types for the custom element
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'ecosystem-window-stack': React.DetailedHTMLProps<
+        React.HTMLAttributes<HTMLElement> & {
+          desktop?: MiniappTargetDesktop;
+          class?: string;
+        },
+        HTMLElement
+      >;
+    }
+  }
+}

--- a/packages/ecosystem-native/react/index.ts
+++ b/packages/ecosystem-native/react/index.ts
@@ -4,6 +4,7 @@
 
 // Wrappers
 export { HomeButtonWrapper, type HomeButtonWrapperProps } from './HomeButtonWrapper';
+export { WindowStackWrapper, type WindowStackWrapperProps } from './WindowStackWrapper';
 // export { EcosystemDesktopWrapper } from './EcosystemDesktopWrapper';
 // export { SplashScreenWrapper } from './SplashScreenWrapper';
 
@@ -14,4 +15,7 @@ export {
   getAnimationLevel,
   isAnimationEnabled,
   initConfig,
+  windowStackManager,
+  type MiniappTargetDesktop,
+  type SlotInfo,
 } from '../src/index';

--- a/packages/ecosystem-native/src/components/types.ts
+++ b/packages/ecosystem-native/src/components/types.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared types for ecosystem-native components
+ */
+
+/**
+ * Target desktop for miniapp presentation
+ */
+export type MiniappTargetDesktop = 'mine' | 'stack';

--- a/packages/ecosystem-native/src/components/window-stack-manager.ts
+++ b/packages/ecosystem-native/src/components/window-stack-manager.ts
@@ -1,0 +1,138 @@
+/**
+ * WindowStack Manager
+ *
+ * Singleton that manages WindowStack instances and provides
+ * synchronous slot access for the miniapp runtime.
+ */
+
+import type { WindowStack, SlotInfo, MiniappTargetDesktop } from '../index';
+
+type SlotCreatedCallback = (slot: SlotInfo) => void;
+type SlotRemovedCallback = (appId: string, desktop: MiniappTargetDesktop) => void;
+
+class WindowStackManager {
+  private stacks = new Map<MiniappTargetDesktop, WindowStack>();
+  private slotCreatedCallbacks = new Set<SlotCreatedCallback>();
+  private slotRemovedCallbacks = new Set<SlotRemovedCallback>();
+
+  /**
+   * Register a WindowStack instance for a desktop.
+   * Called by WindowStackWrapper when the component mounts.
+   */
+  registerStack(desktop: MiniappTargetDesktop, stack: WindowStack): void {
+    this.stacks.set(desktop, stack);
+
+    // Set up callbacks to forward events
+    stack.setCallbacks({
+      onSlotCreated: (slot) => {
+        this.slotCreatedCallbacks.forEach((cb) => cb(slot));
+      },
+      onSlotRemoved: (appId, desktop) => {
+        this.slotRemovedCallbacks.forEach((cb) => cb(appId, desktop));
+      },
+    });
+  }
+
+  /**
+   * Unregister a WindowStack instance.
+   * Called by WindowStackWrapper when the component unmounts.
+   */
+  unregisterStack(desktop: MiniappTargetDesktop): void {
+    const stack = this.stacks.get(desktop);
+    if (stack) {
+      stack.setCallbacks({});
+      this.stacks.delete(desktop);
+    }
+  }
+
+  /**
+   * Get the WindowStack for a desktop.
+   */
+  getStack(desktop: MiniappTargetDesktop): WindowStack | null {
+    return this.stacks.get(desktop) ?? null;
+  }
+
+  /**
+   * Get or create a slot for an app on a specific desktop.
+   * This is SYNCHRONOUS - returns immediately.
+   *
+   * @throws Error if the WindowStack for the desktop is not registered
+   */
+  getOrCreateSlot(desktop: MiniappTargetDesktop, appId: string): HTMLDivElement {
+    const stack = this.stacks.get(desktop);
+    if (!stack) {
+      throw new Error(`WindowStack for desktop "${desktop}" is not registered`);
+    }
+    return stack.getOrCreateSlot(appId);
+  }
+
+  /**
+   * Get an existing slot (returns null if not found).
+   */
+  getSlot(desktop: MiniappTargetDesktop, appId: string): HTMLDivElement | null {
+    const stack = this.stacks.get(desktop);
+    return stack?.getSlot(appId) ?? null;
+  }
+
+  /**
+   * Remove a slot.
+   */
+  removeSlot(desktop: MiniappTargetDesktop, appId: string): void {
+    const stack = this.stacks.get(desktop);
+    stack?.removeSlot(appId);
+  }
+
+  /**
+   * Check if a slot exists.
+   */
+  hasSlot(desktop: MiniappTargetDesktop, appId: string): boolean {
+    const stack = this.stacks.get(desktop);
+    return stack?.hasSlot(appId) ?? false;
+  }
+
+  /**
+   * Set slot visibility.
+   */
+  setSlotHidden(desktop: MiniappTargetDesktop, appId: string, hidden: boolean): void {
+    const stack = this.stacks.get(desktop);
+    stack?.setSlotHidden(appId, hidden);
+  }
+
+  /**
+   * Check if a desktop's WindowStack is registered.
+   */
+  isStackRegistered(desktop: MiniappTargetDesktop): boolean {
+    return this.stacks.has(desktop);
+  }
+
+  /**
+   * Subscribe to slot created events.
+   */
+  onSlotCreated(callback: SlotCreatedCallback): () => void {
+    this.slotCreatedCallbacks.add(callback);
+    return () => this.slotCreatedCallbacks.delete(callback);
+  }
+
+  /**
+   * Subscribe to slot removed events.
+   */
+  onSlotRemoved(callback: SlotRemovedCallback): () => void {
+    this.slotRemovedCallbacks.add(callback);
+    return () => this.slotRemovedCallbacks.delete(callback);
+  }
+
+  /**
+   * Clear all slots on all desktops.
+   */
+  clearAll(): void {
+    for (const stack of this.stacks.values()) {
+      stack.clearAllSlots();
+    }
+  }
+}
+
+/**
+ * Singleton instance of the WindowStack manager.
+ * Use this to access slots synchronously from the miniapp runtime.
+ */
+export const windowStackManager = new WindowStackManager();

--- a/packages/ecosystem-native/src/components/window-stack.test.ts
+++ b/packages/ecosystem-native/src/components/window-stack.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for WindowStack component and manager
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+// Import to register the custom element
+import './window-stack';
+import type { WindowStack } from './window-stack';
+import { windowStackManager } from './window-stack-manager';
+
+describe('WindowStack', () => {
+  let container: HTMLDivElement;
+  let stack: WindowStack;
+
+  beforeEach(async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    stack = document.createElement('ecosystem-window-stack') as WindowStack;
+    stack.desktop = 'mine';
+    container.appendChild(stack);
+
+    // Wait for Lit to render
+    await stack.updateComplete;
+  });
+
+  afterEach(() => {
+    container.remove();
+    // Stack auto-unregisters in disconnectedCallback
+  });
+
+  it('should auto-register with windowStackManager on connect', () => {
+    // Stack should be auto-registered when connected to DOM
+    expect(windowStackManager.isStackRegistered('mine')).toBe(true);
+    expect(windowStackManager.getStack('mine')).toBe(stack);
+  });
+
+  it('should auto-unregister when disconnected', () => {
+    expect(windowStackManager.isStackRegistered('mine')).toBe(true);
+
+    // Remove from DOM
+    stack.remove();
+
+    expect(windowStackManager.isStackRegistered('mine')).toBe(false);
+  });
+
+  it('should create a slot synchronously', () => {
+    const slot = stack.getOrCreateSlot('test-app-1');
+
+    expect(slot).toBeInstanceOf(HTMLDivElement);
+    expect(slot.dataset.appId).toBe('test-app-1');
+    expect(slot.dataset.desktop).toBe('mine');
+    expect(stack.hasSlot('test-app-1')).toBe(true);
+  });
+
+  it('should return existing slot if already created', () => {
+    const slot1 = stack.getOrCreateSlot('test-app-1');
+    const slot2 = stack.getOrCreateSlot('test-app-1');
+
+    expect(slot1).toBe(slot2);
+  });
+
+  it('should remove slot correctly', () => {
+    stack.getOrCreateSlot('test-app-1');
+    expect(stack.hasSlot('test-app-1')).toBe(true);
+
+    stack.removeSlot('test-app-1');
+    expect(stack.hasSlot('test-app-1')).toBe(false);
+    expect(stack.getSlot('test-app-1')).toBeNull();
+  });
+
+  it('should set slot hidden state', () => {
+    const slot = stack.getOrCreateSlot('test-app-1');
+
+    stack.setSlotHidden('test-app-1', true);
+    expect(slot.dataset.hidden).toBe('true');
+    expect(slot.style.display).toBe('none');
+
+    stack.setSlotHidden('test-app-1', false);
+    expect(slot.dataset.hidden).toBe('false');
+    expect(slot.style.display).toBe('');
+  });
+
+  it('should get all slot ids', () => {
+    stack.getOrCreateSlot('app-1');
+    stack.getOrCreateSlot('app-2');
+    stack.getOrCreateSlot('app-3');
+
+    const ids = stack.getSlotIds();
+    expect(ids).toEqual(['app-1', 'app-2', 'app-3']);
+  });
+
+  it('should clear all slots', () => {
+    stack.getOrCreateSlot('app-1');
+    stack.getOrCreateSlot('app-2');
+
+    stack.clearAllSlots();
+
+    expect(stack.hasSlot('app-1')).toBe(false);
+    expect(stack.hasSlot('app-2')).toBe(false);
+    expect(stack.getSlotIds()).toEqual([]);
+  });
+});
+
+describe('windowStackManager', () => {
+  let container: HTMLDivElement;
+  let stack: WindowStack;
+
+  beforeEach(async () => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    stack = document.createElement('ecosystem-window-stack') as WindowStack;
+    stack.desktop = 'mine';
+    container.appendChild(stack);
+    await stack.updateComplete;
+    // Stack is auto-registered in connectedCallback
+  });
+
+  afterEach(() => {
+    container.remove();
+    // Stack auto-unregisters in disconnectedCallback
+  });
+
+  it('should have stack auto-registered', () => {
+    expect(windowStackManager.isStackRegistered('mine')).toBe(true);
+    expect(windowStackManager.getStack('mine')).toBe(stack);
+  });
+
+  it('should create slots via manager', () => {
+    const slot = windowStackManager.getOrCreateSlot('mine', 'test-app-1');
+    expect(slot).toBeInstanceOf(HTMLDivElement);
+    expect(slot.dataset.appId).toBe('test-app-1');
+  });
+
+  it('should throw when stack not registered', () => {
+    expect(() => {
+      windowStackManager.getOrCreateSlot('stack', 'test-app-1');
+    }).toThrow('WindowStack for desktop "stack" is not registered');
+  });
+
+  it('should emit slot created events', () => {
+    let createdSlot: { appId: string; desktop: string } | null = null;
+    const unsub = windowStackManager.onSlotCreated((slot) => {
+      createdSlot = { appId: slot.appId, desktop: slot.desktop };
+    });
+
+    windowStackManager.getOrCreateSlot('mine', 'test-app-1');
+
+    expect(createdSlot).toEqual({ appId: 'test-app-1', desktop: 'mine' });
+
+    unsub();
+  });
+
+  it('should emit slot removed events', () => {
+    windowStackManager.getOrCreateSlot('mine', 'test-app-1');
+
+    let removedInfo: { appId: string; desktop: string } | null = null;
+    const unsub = windowStackManager.onSlotRemoved((appId, desktop) => {
+      removedInfo = { appId, desktop };
+    });
+
+    windowStackManager.removeSlot('mine', 'test-app-1');
+
+    expect(removedInfo).toEqual({ appId: 'test-app-1', desktop: 'mine' });
+
+    unsub();
+  });
+
+  it('should check if slot exists via manager', () => {
+    expect(windowStackManager.hasSlot('mine', 'test-app-1')).toBe(false);
+
+    windowStackManager.getOrCreateSlot('mine', 'test-app-1');
+
+    expect(windowStackManager.hasSlot('mine', 'test-app-1')).toBe(true);
+  });
+
+  it('should set slot hidden via manager', () => {
+    const slot = windowStackManager.getOrCreateSlot('mine', 'test-app-1');
+
+    windowStackManager.setSlotHidden('mine', 'test-app-1', true);
+    expect(slot.dataset.hidden).toBe('true');
+    expect(slot.style.display).toBe('none');
+
+    windowStackManager.setSlotHidden('mine', 'test-app-1', false);
+    expect(slot.dataset.hidden).toBe('false');
+    expect(slot.style.display).toBe('');
+  });
+});

--- a/packages/ecosystem-native/src/components/window-stack.ts
+++ b/packages/ecosystem-native/src/components/window-stack.ts
@@ -1,0 +1,253 @@
+/**
+ * Ecosystem Window Stack - Lit Web Component
+ *
+ * Manages miniapp window slots synchronously to eliminate race conditions.
+ * Replaces React's MiniappWindowStack with direct DOM control.
+ *
+ * NOTE: This component uses Light DOM (no Shadow DOM) to allow:
+ * - React createPortal to work correctly with slot elements
+ * - External CSS to style slot contents
+ * - Proper event bubbling
+ *
+ * IMPORTANT: This component auto-registers with windowStackManager in connectedCallback
+ * to ensure it's available before any launchApp() calls.
+ */
+
+import { LitElement, html } from 'lit';
+import type { MiniappTargetDesktop } from './types';
+import { windowStackManager } from './window-stack-manager';
+
+export interface SlotInfo {
+  appId: string;
+  element: HTMLDivElement;
+  desktop: MiniappTargetDesktop;
+}
+
+/**
+ * Window stack component that manages miniapp slots synchronously.
+ *
+ * Usage:
+ * ```html
+ * <ecosystem-window-stack desktop="mine"></ecosystem-window-stack>
+ * ```
+ *
+ * Key features:
+ * - Synchronous slot creation via getOrCreateSlot()
+ * - Direct DOM control without React rendering delays
+ * - Eliminates race conditions in miniapp launch flow
+ * - Uses Light DOM for React Portal compatibility
+ * - Auto-registers with windowStackManager on connect
+ */
+export class WindowStack extends LitElement {
+  static override properties = {
+    desktop: { type: String },
+  };
+
+  /**
+   * Disable Shadow DOM - render to Light DOM instead.
+   * This is required for React createPortal compatibility.
+   */
+  override createRenderRoot() {
+    return this;
+  }
+
+  /**
+   * Which desktop this stack belongs to ('mine' or 'stack')
+   */
+  desktop: MiniappTargetDesktop = 'mine';
+
+  /**
+   * Internal map of slots by appId
+   */
+  private slots = new Map<string, SlotInfo>();
+
+  /**
+   * The container element for slots
+   */
+  private containerEl: HTMLDivElement | null = null;
+
+  /**
+   * Callback when a slot is created
+   */
+  private onSlotCreated?: (slot: SlotInfo) => void;
+
+  /**
+   * Callback when a slot is removed
+   */
+  private onSlotRemoved?: (appId: string, desktop: MiniappTargetDesktop) => void;
+
+  /**
+   * Auto-register with windowStackManager when connected to DOM.
+   * This ensures the stack is available before any launchApp() calls.
+   */
+  override connectedCallback(): void {
+    super.connectedCallback();
+    // Register immediately when connected to DOM
+    // The desktop attribute should already be set by React
+    if (this.desktop) {
+      windowStackManager.registerStack(this.desktop, this);
+    }
+  }
+
+  /**
+   * Unregister when disconnected from DOM.
+   */
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    if (this.desktop) {
+      windowStackManager.unregisterStack(this.desktop);
+    }
+  }
+
+  /**
+   * Re-register if desktop changes.
+   */
+  override updated(changedProperties: Map<string, unknown>): void {
+    if (changedProperties.has('desktop')) {
+      const oldDesktop = changedProperties.get('desktop') as MiniappTargetDesktop | undefined;
+      if (oldDesktop) {
+        windowStackManager.unregisterStack(oldDesktop);
+      }
+      if (this.desktop) {
+        windowStackManager.registerStack(this.desktop, this);
+      }
+    }
+  }
+
+  /**
+   * Get or create a slot for the given appId.
+   * This is SYNCHRONOUS - the slot is immediately available in the DOM.
+   */
+  getOrCreateSlot(appId: string): HTMLDivElement {
+    const existing = this.slots.get(appId);
+    if (existing) {
+      return existing.element;
+    }
+
+    // Create slot element synchronously
+    const slot = document.createElement('div');
+    slot.style.cssText = 'grid-area: 1 / 1; pointer-events: auto;';
+    slot.dataset.miniappSlot = '';
+    slot.dataset.appId = appId;
+    slot.dataset.desktop = this.desktop;
+
+    const slotInfo: SlotInfo = {
+      appId,
+      element: slot,
+      desktop: this.desktop,
+    };
+
+    this.slots.set(appId, slotInfo);
+
+    // Append to container
+    const container = this.containerEl ?? this.querySelector('.stack-container');
+    if (container) {
+      container.appendChild(slot);
+    }
+
+    // Notify listeners
+    this.onSlotCreated?.(slotInfo);
+
+    return slot;
+  }
+
+  /**
+   * Remove a slot for the given appId.
+   */
+  removeSlot(appId: string): void {
+    const slotInfo = this.slots.get(appId);
+    if (!slotInfo) return;
+
+    slotInfo.element.remove();
+    this.slots.delete(appId);
+
+    this.onSlotRemoved?.(appId, this.desktop);
+  }
+
+  /**
+   * Get an existing slot (returns null if not found).
+   */
+  getSlot(appId: string): HTMLDivElement | null {
+    return this.slots.get(appId)?.element ?? null;
+  }
+
+  /**
+   * Check if a slot exists for the given appId.
+   */
+  hasSlot(appId: string): boolean {
+    return this.slots.has(appId);
+  }
+
+  /**
+   * Set slot visibility.
+   */
+  setSlotHidden(appId: string, hidden: boolean): void {
+    const slot = this.slots.get(appId)?.element;
+    if (slot) {
+      slot.dataset.hidden = String(hidden);
+      slot.style.display = hidden ? 'none' : '';
+    }
+  }
+
+  /**
+   * Get all slot appIds.
+   */
+  getSlotIds(): string[] {
+    return Array.from(this.slots.keys());
+  }
+
+  /**
+   * Set callbacks for slot lifecycle events.
+   */
+  setCallbacks(callbacks: {
+    onSlotCreated?: (slot: SlotInfo) => void;
+    onSlotRemoved?: (appId: string, desktop: MiniappTargetDesktop) => void;
+  }): void {
+    this.onSlotCreated = callbacks.onSlotCreated;
+    this.onSlotRemoved = callbacks.onSlotRemoved;
+  }
+
+  /**
+   * Clear all slots.
+   */
+  clearAllSlots(): void {
+    for (const appId of Array.from(this.slots.keys())) {
+      this.removeSlot(appId);
+    }
+  }
+
+  override firstUpdated() {
+    // Cache the container reference
+    this.containerEl = this.querySelector('.stack-container');
+  }
+
+  override render() {
+    // Using Light DOM, so we use inline styles instead of css``
+    return html`
+      <div
+        class="stack-container"
+        style="
+          display: grid;
+          grid-template-columns: 1fr;
+          grid-template-rows: 1fr;
+          width: 100%;
+          height: 100%;
+          pointer-events: none;
+        "
+        aria-hidden="true"
+        data-testid="ecosystem-window-stack"
+      >
+        <!-- Slots are added dynamically via getOrCreateSlot() -->
+      </div>
+    `;
+  }
+}
+
+// Register the custom element
+customElements.define('ecosystem-window-stack', WindowStack);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ecosystem-window-stack': WindowStack;
+  }
+}

--- a/packages/ecosystem-native/src/index.ts
+++ b/packages/ecosystem-native/src/index.ts
@@ -46,3 +46,8 @@ export {
 
 // Components
 export { HomeButton } from './components/home-button';
+export { WindowStack, type SlotInfo } from './components/window-stack';
+export { windowStackManager } from './components/window-stack-manager';
+
+// Component types
+export { type MiniappTargetDesktop } from './components/types';

--- a/src/components/ecosystem/ecosystem-desktop.tsx
+++ b/src/components/ecosystem/ecosystem-desktop.tsx
@@ -278,7 +278,7 @@ export const EcosystemDesktop = forwardRef<EcosystemDesktopHandle, EcosystemDesk
                 onAppDetail={onAppDetail}
                 onAppRemove={onAppRemove}
               />
-              <MiniappWindowStack />
+              <MiniappWindowStack desktop="mine" />
             </div>
           </SwiperSlide>
 
@@ -287,7 +287,7 @@ export const EcosystemDesktop = forwardRef<EcosystemDesktopHandle, EcosystemDesk
             <SwiperSlide className="!h-full !overflow-hidden">
               <div className="relative z-10 h-full" data-ecosystem-subpage="stack">
                 <AppStackPage />
-                <MiniappWindowStack />
+                <MiniappWindowStack desktop="stack" />
               </div>
             </SwiperSlide>
           )}

--- a/src/components/ecosystem/miniapp-window-stack.tsx
+++ b/src/components/ecosystem/miniapp-window-stack.tsx
@@ -1,107 +1,90 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { Buffer } from 'buffer'
-import { useStore } from '@tanstack/react-store'
+import { useEffect, useRef } from 'react'
 import {
-  miniappRuntimeStore,
-  miniappRuntimeSelectors,
   registerDesktopGridHostRef,
   unregisterDesktopGridHostRef,
   registerDesktopAppSlotRef,
   unregisterDesktopAppSlotRef,
 } from '@/services/miniapp-runtime'
 import type { MiniappTargetDesktop } from '@/services/ecosystem/types'
+import {
+  WindowStackWrapper,
+  windowStackManager,
+  type SlotInfo,
+} from '@biochain/ecosystem-native/react'
 
-function base64UrlEncode(input: string): string {
-  const bytes = new TextEncoder().encode(input)
-  let binary = ''
-  bytes.forEach((b) => {
-    binary += String.fromCharCode(b)
-  })
-
-  const base64 =
-    typeof globalThis.btoa === 'function'
-      ? globalThis.btoa(binary)
-      : Buffer.from(binary, 'binary').toString('base64')
-
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
-}
-
-function isTargetDesktop(value: string | null | undefined): value is MiniappTargetDesktop {
-  return value === 'mine' || value === 'stack'
+export interface MiniappWindowStackProps {
+  /** 指定该 stack 属于哪个桌面，必须传入 */
+  desktop: MiniappTargetDesktop
 }
 
 /**
  * MiniappWindowStack
  *
- * 一个统一的“窗口堆栈层”覆盖网格：
+ * 一个统一的"窗口堆栈层"覆盖网格：
  * - 由 slide 决定布局（本组件只提供 slot 容器）
  * - slot 统一叠放在同一 grid cell（1 / 1）
- * - 本组件不区分 mine/stack 的 props，通过 DOM 上的 `data-ecosystem-subpage` 自识别
+ *
+ * 重构说明：
+ * - 使用 Lit Web Component (WindowStackWrapper) 实现同步 slot 创建
+ * - 消除了 React 异步渲染导致的竞态条件
+ * - slot 现在由 windowStackManager.getOrCreateSlot() 同步创建
+ * - desktop 必须通过 prop 传入，确保首次渲染就能注册 WindowStack
  */
-export function MiniappWindowStack() {
+export function MiniappWindowStack({ desktop }: MiniappWindowStackProps) {
   const rootRef = useRef<HTMLDivElement>(null)
-  const [desktop, setDesktop] = useState<MiniappTargetDesktop | null>(null)
-
-  const presentations = useStore(miniappRuntimeStore, miniappRuntimeSelectors.getPresentations)
-
-  // 通过 DOM 祖先自识别该层属于 mine 还是 stack
-  useEffect(() => {
-    const root = rootRef.current
-    if (!root) return
-
-    const page = root.closest('[data-ecosystem-subpage]')?.getAttribute('data-ecosystem-subpage') ?? null
-    setDesktop(isTargetDesktop(page) ? page : null)
-  }, [])
 
   // 注册/注销 grid host ref（便于 runtime 定位）
   useEffect(() => {
     const root = rootRef.current
-    if (!root || !desktop) return
+    if (!root) return
 
     registerDesktopGridHostRef(desktop, root)
     return () => unregisterDesktopGridHostRef(desktop)
   }, [desktop])
 
-  const slotPresentations = useMemo(() => {
-    if (!desktop) return []
-    return presentations.filter((p) => p.desktop === desktop && p.state !== 'hidden')
-  }, [desktop, presentations])
+  // 监听 Lit 组件的 slot 创建/销毁事件，同步到 runtime-refs
+  useEffect(() => {
+    const handleSlotCreated = (slot: SlotInfo) => {
+      if (slot.desktop === desktop) {
+        registerDesktopAppSlotRef(desktop, slot.appId, slot.element)
+      }
+    }
 
+    const handleSlotRemoved = (appId: string, slotDesktop: MiniappTargetDesktop) => {
+      if (slotDesktop === desktop) {
+        unregisterDesktopAppSlotRef(desktop, appId)
+      }
+    }
+
+    const unsubCreate = windowStackManager.onSlotCreated(handleSlotCreated)
+    const unsubRemove = windowStackManager.onSlotRemoved(handleSlotRemoved)
+
+    return () => {
+      unsubCreate()
+      unsubRemove()
+    }
+  }, [desktop])
+
+  // 保持与原版完全一致的样式结构
   return (
     <div
       ref={rootRef}
-      className="absolute left-0 right-0 top-0 z-20 grid"
+      className="absolute left-0 right-0 top-0 z-20"
       style={{
         bottom: 'var(--tab-bar-height)',
         pointerEvents: 'none',
-        gridTemplateColumns: '1fr',
-        gridTemplateRows: '1fr',
       }}
       aria-hidden={true}
       data-testid="miniapp-window-stack"
     >
-      {slotPresentations.map((p) => {
-        const areaName = base64UrlEncode(p.appId)
-        const setSlotRef = (el: HTMLDivElement | null) => {
-          if (!desktop) return
-          if (el) {
-            registerDesktopAppSlotRef(desktop, p.appId, el)
-            return
-          }
-          unregisterDesktopAppSlotRef(desktop, p.appId)
-        }
-
-        return (
-          <div
-            key={p.appId}
-            ref={setSlotRef}
-            style={{ gridArea: '1 / 1', pointerEvents: 'auto' }}
-            data-miniapp-slot
-            data-app-id={p.appId}
-            data-area-name={areaName}
-          />
-        )
-      })}
+      <WindowStackWrapper
+        desktop={desktop}
+        style={{
+          display: 'block',
+          width: '100%',
+          height: '100%',
+        }}
+      />
     </div>
   )
 }

--- a/src/components/ecosystem/my-apps-page.module.css
+++ b/src/components/ecosystem/my-apps-page.module.css
@@ -22,11 +22,11 @@
 
 /* 菜单模式：popover 打开时固定定位 */
 .iconPopover:popover-open:not([data-launching]) {
-  position: fixed;
-  inset: auto;
-  top: var(--popover-top);
-  left: var(--popover-left);
-  margin: 0;
+  position: fixed !important;
+  inset: auto !important;
+  top: var(--popover-top) !important;
+  left: var(--popover-left) !important;
+  margin: 0 !important;
   z-index: 50;
 }
 

--- a/src/components/ecosystem/my-apps-page.tsx
+++ b/src/components/ecosystem/my-apps-page.tsx
@@ -123,6 +123,10 @@ function IOSDesktopIcon({ app, onTap, onOpen, onDetail, onRemove }: IOSDesktopIc
 
     setMenuPosition({ top: menuTop, left: menuLeft });
 
+    // 设置 CSS 变量供 :popover-open 状态使用
+    popover.style.setProperty('--popover-top', `${rect.top}px`);
+    popover.style.setProperty('--popover-left', `${rect.left}px`);
+
     // 用 Web Animation API 设置 popover 位置（fill: forwards 保持最终状态）
     popoverAnimationRef.current = popover.animate(
       [
@@ -264,6 +268,8 @@ function IOSDesktopIcon({ app, onTap, onOpen, onDetail, onRemove }: IOSDesktopIc
 
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
+    // 如果已经通过 touch long-press 打开了菜单，跳过
+    if (isOpen || didLongPress.current) return;
     showMenu();
   };
 

--- a/src/services/miniapp-runtime/container/iframe-container.ts
+++ b/src/services/miniapp-runtime/container/iframe-container.ts
@@ -64,7 +64,11 @@ class IframeContainerHandle implements ContainerHandle {
 export class IframeContainerManager implements ContainerManager {
   readonly type = 'iframe' as const;
 
-  async create(options: ContainerCreateOptions): Promise<IframeContainerHandle> {
+  /**
+   * Synchronous container creation.
+   * Creates the iframe and appends it to the mount target immediately.
+   */
+  createSync(options: ContainerCreateOptions): IframeContainerHandle {
     const { appId, url, mountTarget, contextParams, onLoad } = options;
 
     const iframe = document.createElement('iframe');
@@ -98,6 +102,11 @@ export class IframeContainerManager implements ContainerManager {
     mountTarget.appendChild(iframe);
 
     return new IframeContainerHandle(iframe, mountTarget);
+  }
+
+  async create(options: ContainerCreateOptions): Promise<IframeContainerHandle> {
+    // Delegate to sync version
+    return this.createSync(options);
   }
 }
 

--- a/src/services/miniapp-runtime/container/index.ts
+++ b/src/services/miniapp-runtime/container/index.ts
@@ -18,3 +18,17 @@ export async function createContainer(type: ContainerType, options: ContainerCre
   const manager = getContainerManager(type);
   return manager.create(options);
 }
+
+/**
+ * Synchronous container creation (iframe only).
+ * Use this when you need the container handle immediately without Promise delay.
+ *
+ * @throws Error if the container type doesn't support sync creation (e.g., wujie)
+ */
+export function createContainerSync(type: ContainerType, options: ContainerCreateOptions): ContainerHandle {
+  const manager = getContainerManager(type);
+  if (!manager.createSync) {
+    throw new Error(`Container type "${type}" does not support synchronous creation`);
+  }
+  return manager.createSync(options);
+}

--- a/src/services/miniapp-runtime/container/types.ts
+++ b/src/services/miniapp-runtime/container/types.ts
@@ -24,4 +24,9 @@ export interface ContainerCreateOptions {
 export interface ContainerManager {
   readonly type: ContainerType;
   create(options: ContainerCreateOptions): Promise<ContainerHandle>;
+  /**
+   * Synchronous container creation (for iframe type only).
+   * Returns the handle immediately without Promise wrapping.
+   */
+  createSync?(options: ContainerCreateOptions): ContainerHandle;
 }

--- a/src/services/miniapp-runtime/container/wujie-container.ts
+++ b/src/services/miniapp-runtime/container/wujie-container.ts
@@ -138,6 +138,9 @@ export class WujieContainerManager implements ContainerManager {
     const container = document.createElement('div');
     container.id = `miniapp-wujie-${appId}`;
     container.className = 'size-full *:size-full *:block *:overflow-auto';
+    // Hide container initially to prevent flash before animation starts
+    // The animation layer will control visibility via opacity
+    container.style.display = 'none';
 
     mountTarget.appendChild(container);
 


### PR DESCRIPTION
## Summary

This PR fixes several race conditions and UI issues in the miniapp launch flow.

### Changes

1. **WindowStack Lit Web Component** - New synchronous slot management system
   - `window-stack.ts`: Lit component for managing miniapp slots
   - `window-stack-manager.ts`: Singleton manager for cross-component access
   - `WindowStackWrapper.tsx`: React wrapper component
   - Auto-registers in `connectedCallback` for immediate availability

2. **Wujie Container Animation Fix**
   - Hide container initially (`display: none`) to prevent flash before animation starts
   - Container is shown when animation layer is ready

3. **Long-press Menu Fixes**
   - Fix popover positioning by setting `--popover-top` and `--popover-left` CSS variables
   - Add `!important` to override base `inset: auto !important`
   - Fix double popup on mobile by checking `didLongPress` state

4. **Unified Container Mount Flow**
   - Both iframe and wujie containers now use `windowStackManager` for slot management
   - Synchronous slot creation eliminates race conditions

### Testing

- [x] Type check passes
- [x] WindowStack unit tests added
- [ ] Manual testing on iOS Safari
- [ ] Manual testing on desktop browsers