### PR TITLE
feat(sources): improve source management with edit mode and auto-fetch name

### DIFF
--- a/src/i18n/locales/ar/common.json
+++ b/src/i18n/locales/ar/common.json
@@ -489,6 +489,7 @@
     "noSources": "لا توجد مصادر",
     "urlPlaceholder": "عنوان URL للاشتراك (https://...)",
     "namePlaceholder": "الاسم (اختياري)",
+    "nameWithDefault": "الاسم ({{name}})",
     "addSource": "إضافة مصدر",
     "official": "رسمي",
     "updatedAt": "تم التحديث {{date}}",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -489,6 +489,7 @@
     "noSources": "No sources",
     "urlPlaceholder": "Subscription URL (https://...)",
     "namePlaceholder": "Name (optional)",
+    "nameWithDefault": "Name ({{name}})",
     "addSource": "Add source",
     "official": "Official",
     "updatedAt": "Updated {{date}}",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -489,6 +489,7 @@
     "noSources": "暂无订阅源",
     "urlPlaceholder": "订阅 URL (https://...)",
     "namePlaceholder": "名称 (可选)",
+    "nameWithDefault": "名称 ({{name}})",
     "addSource": "添加订阅源",
     "official": "官方",
     "updatedAt": "更新于 {{date}}",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -489,6 +489,7 @@
     "noSources": "暫無訂閱源",
     "urlPlaceholder": "訂閱 URL (https://...)",
     "namePlaceholder": "名稱 (可選)",
+    "nameWithDefault": "名稱 ({{name}})",
     "addSource": "添加訂閱源",
     "official": "官方",
     "updatedAt": "更新於 {{date}}",

--- a/src/stores/ecosystem.ts
+++ b/src/stores/ecosystem.ts
@@ -370,6 +370,14 @@ export const ecosystemActions = {
     }));
   },
 
+  /** 更新订阅源名称 */
+  updateSourceName: (url: string, name: string): void => {
+    ecosystemStore.setState((state) => ({
+      ...state,
+      sources: state.sources.map((s) => (s.url === url ? { ...s, name } : s)),
+    }));
+  },
+
   /** 更新订阅源时间 */
   updateSourceTimestamp: (url: string): void => {
     ecosystemStore.setState((state) => ({


### PR DESCRIPTION
## Summary

Improves the source management page with better UX for adding and editing sources.

### Changes

1. **Edit Mode for Existing Sources**
   - Click on any source to enter edit mode
   - Bottom area transforms from "Add" to "Save" mode
   - Selected source is highlighted with ring

2. **Auto-fetch Source Name**
   - When entering a URL, automatically fetches the source JSON
   - Extracts the `name` field from the source
   - Shows fetched name as placeholder: "Name (FetchedName)"
   - Falls back to "Custom source" if fetch fails

3. **Immediate Refresh After Add/Save**
   - Triggers `refreshSource()` immediately after adding or saving
   - User sees updated data right away

4. **New Store Action**
   - Added `updateSourceName` action to ecosystem store

5. **Translations**
   - Added `nameWithDefault` key to all locales (en, zh-CN, zh-TW, ar)

### Testing

- [x] Type check passes
- [ ] Manual testing