### PR TITLE
fix: allow context menu for input and textarea

### DIFF
--- a/src/lib/context-menu-guard.test.ts
+++ b/src/lib/context-menu-guard.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { shouldBlockContextMenu } from './context-menu-guard'
+
+describe('shouldBlockContextMenu', () => {
+  it('should allow input element', () => {
+    const input = document.createElement('input')
+    expect(shouldBlockContextMenu(input)).toBe(false)
+  })
+
+  it('should allow textarea element', () => {
+    const textarea = document.createElement('textarea')
+    expect(shouldBlockContextMenu(textarea)).toBe(false)
+  })
+
+  it('should allow contenteditable element', () => {
+    const editable = document.createElement('div')
+    editable.setAttribute('contenteditable', 'true')
+    expect(shouldBlockContextMenu(editable)).toBe(false)
+  })
+
+  it('should allow children inside contenteditable element', () => {
+    const editable = document.createElement('div')
+    editable.setAttribute('contenteditable', 'true')
+    const child = document.createElement('span')
+    editable.appendChild(child)
+
+    expect(shouldBlockContextMenu(child)).toBe(false)
+  })
+
+  it('should allow nodes inside explicit allow-context-menu container', () => {
+    const container = document.createElement('div')
+    container.dataset.allowContextMenu = 'true'
+    const child = document.createElement('button')
+    container.appendChild(child)
+
+    expect(shouldBlockContextMenu(child)).toBe(false)
+  })
+
+  it('should block context menu for regular elements', () => {
+    const div = document.createElement('div')
+    expect(shouldBlockContextMenu(div)).toBe(true)
+  })
+
+  it('should block when target is null', () => {
+    expect(shouldBlockContextMenu(null)).toBe(true)
+  })
+})

--- a/src/lib/context-menu-guard.ts
+++ b/src/lib/context-menu-guard.ts
@@ -1,0 +1,23 @@
+const CONTEXT_MENU_ALLOW_SELECTOR = [
+  '[data-allow-context-menu="true"]',
+  'input',
+  'textarea',
+  '[contenteditable=""]',
+  '[contenteditable="true"]',
+  '[contenteditable="plaintext-only"]',
+].join(', ')
+
+function toElement(target: EventTarget | null): Element | null {
+  if (target instanceof Element) return target
+  if (target instanceof Node) return target.parentElement
+  return null
+}
+
+/**
+ * Returns true when KeyApp should block browser context menu.
+ */
+export function shouldBlockContextMenu(target: EventTarget | null): boolean {
+  const element = toElement(target)
+  if (!element) return true
+  return !element.closest(CONTEXT_MENU_ALLOW_SELECTOR)
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,13 +4,14 @@ import './lib/superjson'
 import './polyfills'
 import { startServiceMain } from './service-main'
 import { startFrontendMain } from './frontend-main'
+import { shouldBlockContextMenu } from './lib/context-menu-guard'
 
 // 禁用右键菜单（移动端 App 体验）
 document.addEventListener('contextmenu', (event) => {
-  const target = event.target as HTMLElement | null
-  if (target?.closest?.('[data-allow-context-menu="true"]')) {
+  if (!shouldBlockContextMenu(event.target)) {
     return
   }
+
   event.preventDefault()
 })
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -92,10 +92,13 @@ body {
   -webkit-tap-highlight-color: transparent;
 }
 
-/* 允许输入框选择文本 */
+/* 允许输入框选择文本和菜单 */
 input,
 textarea,
-[contenteditable='true'] {
+[contenteditable=''],
+[contenteditable='true'],
+[contenteditable='plaintext-only'] {
+  -webkit-touch-callout: default;
   -webkit-user-select: text;
   user-select: text;
 }


### PR DESCRIPTION
## Summary
- extract global context-menu blocking into `shouldBlockContextMenu()` guard
- exempt editable controls (`input`, `textarea`, `contenteditable`) from global menu suppression
- keep explicit allowlist support via `data-allow-context-menu="true"`
- add unit tests for editable and non-editable targets
- allow iOS long-press callout on editable controls in global CSS

## Validation
- `pnpm -s vitest run src/lib/context-menu-guard.test.ts`
- `pnpm check`
