### PR TITLE
fix: source URL textarea + dweb metadata URL assembly

### DIFF
--- a/src/stackflow/activities/SettingsSourcesActivity.tsx
+++ b/src/stackflow/activities/SettingsSourcesActivity.tsx
@@ -219,16 +219,16 @@ export const SettingsSourcesActivity: ActivityComponentType = () => {
         {/* Add/Edit Source */}
         {isEditing ? (
           <div className="bg-background space-y-3 border-t p-4">
-            <input
-              type="url"
+            <textarea
               value={newUrl}
               onChange={(e) => {
                 setNewUrl(e.target.value);
                 setError(null);
               }}
               placeholder={t('sources.urlPlaceholder')}
-              className="bg-background focus:ring-primary w-full rounded-lg border px-3 py-2 focus:ring-2 focus:outline-none"
-              disabled={editingUrl !== null && editingUrl === newUrl}
+              rows={1}
+              spellCheck={false}
+              className="bg-background focus:ring-primary w-full resize-none rounded-lg border px-3 py-2 [field-sizing:content] focus:ring-2 focus:outline-none"
             />
             <div className="relative">
               <input

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -117,7 +117,12 @@ export default defineConfig(({ mode }) => {
   // DWEB 更新地址由 SITE_ORIGIN + SITE_BASE_URL 拼接，二者必须成对配置。
   // 注意：这里不要误用 VITE_BASE_URL（它是构建资源的 base），否则会导致更新 URL 丢失站点路径。
   const siteOrigin = env.SITE_ORIGIN ?? process.env.SITE_ORIGIN ?? 'https://bioforestchain.github.io/KeyApp/';
-  const siteBaseUrl = env.SITE_BASE_URL ?? process.env.SITE_BASE_URL ?? BASE_URL;
+  const siteBaseUrl =
+    env.SITE_BASE_URL ??
+    process.env.SITE_BASE_URL ??
+    env.VITEPRESS_BASE ??
+    process.env.VITEPRESS_BASE ??
+    BASE_URL;
 
   const buildTime = new Date();
   const pad = (value: number) => value.toString().padStart(2, '0');


### PR DESCRIPTION
## Summary\n- switch miniapp source URL editor from input to editable textarea\n- enable auto sizing with Tailwind v4 field-sizing content\n- fix dweb site base fallback to use SITE_BASE_URL -> VITEPRESS_BASE -> BASE_URL\n- add tests for GitHub Pages/CD env URL assembly and check update fetch URL\n\n## Validation\n- pnpm vitest run --project=unit src/lib/__tests__/dweb-update.test.ts\n- pnpm check\n