### PR TITLE
fix: miniapp auth popup consistency + chain pipeline compatibility

### DIFF
--- a/src/components/security/pattern-lock.tsx
+++ b/src/components/security/pattern-lock.tsx
@@ -17,6 +17,8 @@ export interface PatternLockProps {
   error?: boolean;
   /** 成功状态 */
   success?: boolean;
+  /** 错误提示文案（可选，覆盖默认错误文案） */
+  errorText?: string;
   /** 额外的 className */
   className?: string;
   /** 网格大小 (默认 3x3) */
@@ -48,6 +50,7 @@ export function PatternLock({
   disabled = false,
   error = false,
   success = false,
+  errorText,
   className,
   size = 3,
   'data-testid': testId,
@@ -496,7 +499,7 @@ export function PatternLock({
       <div className="text-center h-5">
         {error || isErrorAnimating ? (
           <p className="text-destructive text-sm">
-            {t('patternLock.error')}
+            {errorText ?? t('patternLock.error')}
           </p>
         ) : selectedNodes.length === 0 ? (
           <p className="text-muted-foreground text-sm">

--- a/src/services/chain-config/index.ts
+++ b/src/services/chain-config/index.ts
@@ -397,5 +397,8 @@ export function getEnabledChains(snapshot: ChainConfigSnapshot): ChainConfig[] {
 }
 
 export function getChainById(snapshot: ChainConfigSnapshot, id: string): ChainConfig | null {
-  return snapshot.configs.find((c) => c.id === id) ?? null
+  const normalizedId = id.trim().toLowerCase()
+  return snapshot.configs.find((c) => c.id === id)
+    ?? snapshot.configs.find((c) => c.id.toLowerCase() === normalizedId)
+    ?? null
 }

--- a/src/services/ecosystem/__tests__/transfer-handler.test.ts
+++ b/src/services/ecosystem/__tests__/transfer-handler.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EcosystemTransferParams } from '../types'
+import { BioErrorCodes } from '../types'
+import { handleSendTransaction, setTransferDialog } from '../handlers/transfer'
+import { HandlerContext } from '../handlers/context'
+
+const baseContext = {
+  appId: 'test-miniapp',
+  appName: 'Test Miniapp',
+  appIcon: 'https://miniapp.example/icon.png',
+  origin: 'https://test.app',
+  permissions: ['bio_sendTransaction'],
+}
+
+const baseParams: EcosystemTransferParams = {
+  from: 'b_sender',
+  to: 'b_receiver',
+  amount: '1.25',
+  chain: 'bfmeta',
+}
+
+describe('handleSendTransaction', () => {
+  beforeEach(() => {
+    HandlerContext.clear()
+    setTransferDialog(null)
+  })
+
+  it('passes miniapp icon from handler context', async () => {
+    const showTransferDialog = vi.fn(async () => ({
+      txHash: 'tx-hash-ctx-icon',
+      txId: 'tx-hash-ctx-icon',
+      transaction: { hash: 'tx-hash-ctx-icon' },
+    }))
+
+    HandlerContext.register(baseContext.appId, {
+      showWalletPicker: async () => null,
+      getConnectedAccounts: () => [],
+      showSigningDialog: async () => null,
+      showTransferDialog,
+      showSignTransactionDialog: async () => null,
+    })
+
+    await handleSendTransaction(baseParams, baseContext)
+
+    expect(showTransferDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        app: {
+          name: baseContext.appName,
+          icon: baseContext.appIcon,
+        },
+      }),
+    )
+  })
+
+  it('returns normalized object transaction for new callback shape', async () => {
+    HandlerContext.register(baseContext.appId, {
+      showWalletPicker: async () => null,
+      getConnectedAccounts: () => [],
+      showSigningDialog: async () => null,
+      showTransferDialog: async () => ({
+        txHash: 'tx-hash-1',
+        txId: 'tx-hash-1',
+        transaction: { hash: 'tx-hash-1', type: 'AST-01', senderId: 'b_sender' },
+      }),
+      showSignTransactionDialog: async () => null,
+    })
+
+    const result = await handleSendTransaction(baseParams, baseContext)
+
+    expect(result).toEqual({
+      txHash: 'tx-hash-1',
+      txId: 'tx-hash-1',
+      transaction: { hash: 'tx-hash-1', type: 'AST-01', senderId: 'b_sender' },
+    })
+    expect(typeof (result as { transaction: unknown }).transaction).toBe('object')
+  })
+
+  it('keeps backward compatibility for legacy txHash-only callback', async () => {
+    HandlerContext.register(baseContext.appId, {
+      showWalletPicker: async () => null,
+      getConnectedAccounts: () => [],
+      showSigningDialog: async () => null,
+      showTransferDialog: async () => ({ txHash: 'legacy-hash' }),
+      showSignTransactionDialog: async () => null,
+    })
+
+    const result = await handleSendTransaction(baseParams, baseContext)
+
+    expect(result).toEqual({
+      txHash: 'legacy-hash',
+      txId: 'legacy-hash',
+      transaction: {
+        txId: 'legacy-hash',
+        txHash: 'legacy-hash',
+      },
+    })
+    expect(typeof (result as { transaction: unknown }).transaction).toBe('object')
+  })
+
+  it('rejects invalid callback payload without tx id', async () => {
+    HandlerContext.register(baseContext.appId, {
+      showWalletPicker: async () => null,
+      getConnectedAccounts: () => [],
+      showSigningDialog: async () => null,
+      showTransferDialog: async () => ({ txHash: '' }),
+      showSignTransactionDialog: async () => null,
+    })
+
+    await expect(handleSendTransaction(baseParams, baseContext)).rejects.toMatchObject({
+      code: BioErrorCodes.INTERNAL_ERROR,
+      message: 'Invalid transfer result: missing tx id',
+    })
+  })
+})

--- a/src/services/ecosystem/handlers/context.ts
+++ b/src/services/ecosystem/handlers/context.ts
@@ -3,7 +3,14 @@
  * 管理小程序回调的注册中心，支持多实例
  */
 
-import type { BioAccount, EcosystemTransferParams, EcosystemDestroyParams, UnsignedTransaction, SignedTransaction } from '../types'
+import type {
+  BioAccount,
+  EcosystemTransferParams,
+  EcosystemDestroyParams,
+  UnsignedTransaction,
+  SignedTransaction,
+  HandlerContext as EcosystemHandlerContext,
+} from '../types'
 
 /** EVM 交易请求类型 */
 export interface EvmTransactionRequest {
@@ -31,6 +38,16 @@ export interface TronTransaction {
 export interface MiniappInfo {
   name: string
   icon?: string
+}
+
+/**
+ * 从 handler context 构造统一的 miniapp 信息。
+ */
+export function toMiniappInfo(context: Pick<EcosystemHandlerContext, 'appName' | 'appIcon'>): MiniappInfo {
+  const icon = context.appIcon?.trim()
+  return icon
+    ? { name: context.appName, icon }
+    : { name: context.appName }
 }
 
 /** 签名参数 */
@@ -74,13 +91,23 @@ export interface TronSigningParams {
   appName: string
 }
 
+/** 转账对话框返回值 */
+export interface TransferDialogResult {
+  /** 链上交易 ID（兼容旧字段） */
+  txHash: string
+  /** 语义化别名：交易 ID */
+  txId?: string
+  /** 可序列化交易对象（供调用方直接提交后端） */
+  transaction?: Record<string, unknown>
+}
+
 /** Handler 回调接口 */
 export interface HandlerCallbacks {
   // Bio (BioChain) callbacks
   showWalletPicker: (opts?: { chain?: string; exclude?: string; app?: MiniappInfo }) => Promise<BioAccount | null>
   getConnectedAccounts: () => BioAccount[]
   showSigningDialog: (params: SigningParams) => Promise<SigningResult | null>
-  showTransferDialog: (params: EcosystemTransferParams & { app: MiniappInfo }) => Promise<{ txHash: string } | null>
+  showTransferDialog: (params: EcosystemTransferParams & { app: MiniappInfo }) => Promise<TransferDialogResult | null>
   showDestroyDialog?: (params: EcosystemDestroyParams & { app: MiniappInfo }) => Promise<{ txHash: string } | null>
   showSignTransactionDialog: (params: SignTransactionParams) => Promise<SignedTransaction | null>
 

--- a/src/services/ecosystem/handlers/destroy.ts
+++ b/src/services/ecosystem/handlers/destroy.ts
@@ -4,7 +4,7 @@
 
 import type { MethodHandler, EcosystemDestroyParams } from '../types'
 import { BioErrorCodes } from '../types'
-import { HandlerContext, type MiniappInfo } from './context'
+import { HandlerContext, type MiniappInfo, toMiniappInfo } from './context'
 
 // 兼容旧 API
 let _showDestroyDialog: ((params: EcosystemDestroyParams & { app: MiniappInfo }) => Promise<{ txHash: string } | null>) | null = null
@@ -40,7 +40,7 @@ export const handleDestroyAsset: MethodHandler = async (params, context) => {
     amount: opts.amount,
     chain: opts.chain,
     asset: opts.asset,
-    app: { name: context.appName },
+    app: toMiniappInfo(context),
   }
 
   const result = await showDestroyDialog(destroyParams)

--- a/src/services/ecosystem/handlers/signing.ts
+++ b/src/services/ecosystem/handlers/signing.ts
@@ -4,7 +4,7 @@
 
 import type { MethodHandler } from '../types'
 import { BioErrorCodes } from '../types'
-import { HandlerContext, type SigningParams, type SigningResult } from './context'
+import { HandlerContext, type SigningParams, type SigningResult, toMiniappInfo } from './context'
 
 // 兼容旧 API（现在返回 SigningResult）
 let _showSigningDialog: ((params: SigningParams) => Promise<SigningResult | null>) | null = null
@@ -36,7 +36,7 @@ export const handleSignMessage: MethodHandler = async (params, context) => {
     message: opts.message,
     address: opts.address,
     chainName: opts.chainName,
-    app: { name: context.appName },
+    app: toMiniappInfo(context),
   })
 
   if (!result) {
@@ -66,7 +66,7 @@ export const handleSignTypedData: MethodHandler = async (params, context) => {
     message,
     address: opts.address,
     chainName: opts.chainName,
-    app: { name: context.appName },
+    app: toMiniappInfo(context),
   })
 
   if (!result) {

--- a/src/stackflow/activities/MainTabsActivity.tsx
+++ b/src/stackflow/activities/MainTabsActivity.tsx
@@ -138,14 +138,20 @@ export const MainTabsActivity: ActivityComponentType<MainTabsParams> = ({ params
     });
 
     setTransferDialog(async (params: EcosystemTransferParams & { app: { name: string; icon?: string } }) => {
-      return new Promise<{ txHash: string } | null>((resolve) => {
+      return new Promise<{ txHash: string; txId?: string; transaction?: Record<string, unknown> } | null>((resolve) => {
         const timeout = window.setTimeout(() => resolve(null), 60_000);
 
         const handleResult = (e: Event) => {
           window.clearTimeout(timeout);
-          const detail = (e as CustomEvent).detail as { confirmed?: boolean; txHash?: string } | undefined;
+          const detail = (e as CustomEvent).detail as
+            | { confirmed?: boolean; txHash?: string; txId?: string; transaction?: Record<string, unknown> }
+            | undefined;
           if (detail?.confirmed && detail.txHash) {
-            resolve({ txHash: detail.txHash });
+            resolve({
+              txHash: detail.txHash,
+              txId: detail.txId,
+              transaction: detail.transaction,
+            });
             return;
           }
           resolve(null);

--- a/src/stackflow/activities/sheets/MiniappTransferConfirmJob.tsx
+++ b/src/stackflow/activities/sheets/MiniappTransferConfirmJob.tsx
@@ -3,150 +3,162 @@
  * 用于小程序请求发送转账时显示
  */
 
-import { useState, useCallback } from 'react';
-import type { ActivityComponentType } from '@stackflow/react';
-import { BottomSheet } from '@/components/layout/bottom-sheet';
-import { useTranslation } from 'react-i18next';
-import { cn } from '@/lib/utils';
-import { IconArrowDown, IconAlertTriangle, IconLoader2 } from '@tabler/icons-react';
-import { useFlow } from '../../stackflow';
-import { ActivityParamsProvider, useActivityParams } from '../../hooks';
-import { setWalletLockConfirmCallback } from './WalletLockConfirmJob';
-import { useCurrentWallet, walletStore } from '@/stores';
-import { SignatureAuthService, plaocAdapter } from '@/services/authorize';
-import { AddressDisplay } from '@/components/wallet/address-display';
-import { AmountDisplay } from '@/components/common/amount-display';
-import { MiniappSheetHeader } from '@/components/ecosystem';
-import { ChainBadge } from '@/components/wallet/chain-icon';
+import { useState, useCallback, useMemo } from 'react'
+import type { ActivityComponentType } from '@stackflow/react'
+import { BottomSheet } from '@/components/layout/bottom-sheet'
+import { useTranslation } from 'react-i18next'
+import { cn } from '@/lib/utils'
+import { IconArrowDown, IconAlertTriangle, IconLoader2 } from '@tabler/icons-react'
+import { useFlow } from '../../stackflow'
+import { ActivityParamsProvider, useActivityParams } from '../../hooks'
+import { setWalletLockConfirmCallback } from './WalletLockConfirmJob'
+import { walletStore } from '@/stores'
+import { AddressDisplay } from '@/components/wallet/address-display'
+import { AmountDisplay } from '@/components/common/amount-display'
+import { MiniappSheetHeader } from '@/components/ecosystem'
+import { ChainBadge } from '@/components/wallet/chain-icon'
+import { getChainProvider } from '@/services/chain-adapter/providers'
+import { Amount } from '@/types/amount'
+import { signUnsignedTransaction } from '@/services/ecosystem/handlers'
+import { chainConfigService } from '@/services/chain-config/service'
+import { findMiniappWalletIdByAddress, resolveMiniappChainId } from './miniapp-wallet'
 
 type MiniappTransferConfirmJobParams = {
   /** 来源小程序名称 */
-  appName: string;
+  appName: string
   /** 来源小程序图标 */
-  appIcon?: string;
+  appIcon?: string
   /** 发送地址 */
-  from: string;
+  from: string
   /** 接收地址 */
-  to: string;
+  to: string
   /** 金额 */
-  amount: string;
+  amount: string
   /** 链 ID */
-  chain: string;
+  chain: string
   /** 代币 (可选) */
-  asset?: string;
-};
+  asset?: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
 
 function MiniappTransferConfirmJobContent() {
-  const { t } = useTranslation('common');
-  const { pop, push } = useFlow();
-  const params = useActivityParams<MiniappTransferConfirmJobParams>();
-  const { appName, appIcon, from, to, amount, chain, asset } = params;
-  const currentWallet = useCurrentWallet();
+  const { t } = useTranslation('common')
+  const { pop, push } = useFlow()
+  const params = useActivityParams<MiniappTransferConfirmJobParams>()
+  const { appName, appIcon, from, to, amount, chain, asset } = params
 
-  const [isConfirming, setIsConfirming] = useState(false);
+  const [isConfirming, setIsConfirming] = useState(false)
 
-  // 查找使用该地址的钱包
-  const targetWallet = walletStore.state.wallets.find((w) => w.chainAddresses.some((ca) => ca.address === from));
-  const walletName = targetWallet?.name || t('unknownWallet');
+  const resolvedChainId = useMemo(() => resolveMiniappChainId(chain), [chain])
+  const walletId = useMemo(() => findMiniappWalletIdByAddress(resolvedChainId, from), [resolvedChainId, from])
+  const targetWallet = walletStore.state.wallets.find((wallet) => wallet.id === walletId)
+  const walletName = targetWallet?.name || t('unknownWallet')
+  const lockDescription = `${appName || t('unknownDApp')} ${t('requestsTransfer')}`
+
+  const displayAsset = useMemo(() => {
+    if (asset) return asset
+    const chainSymbol = chainConfigService.getSymbol(resolvedChainId)
+    return chainSymbol || resolvedChainId.toUpperCase()
+  }, [asset, resolvedChainId])
 
   const handleConfirm = useCallback(() => {
-    if (isConfirming) return;
+    if (isConfirming || !walletId) return
 
-    // 设置钱包锁验证回调
     setWalletLockConfirmCallback(async (password: string) => {
-      setIsConfirming(true);
+      setIsConfirming(true)
 
       try {
-        const encryptedSecret = currentWallet?.encryptedMnemonic;
-        if (!encryptedSecret) {
-          return false;
+        const provider = getChainProvider(resolvedChainId)
+        if (!provider.supportsFullTransaction || !provider.buildTransaction || !provider.signTransaction || !provider.broadcastTransaction) {
+          throw new Error(`Chain ${resolvedChainId} does not support transaction pipeline`)
         }
 
-        // 创建签名服务
-        const eventId = `miniapp_transfer_${Date.now()}`;
-        const authService = new SignatureAuthService(plaocAdapter, eventId);
+        const decimals = chainConfigService.getDecimals(resolvedChainId)
+        const chainSymbol = chainConfigService.getSymbol(resolvedChainId)
+        const symbol = (asset ?? chainSymbol) || resolvedChainId.toUpperCase()
+        const valueAmount = Amount.parse(amount, decimals, symbol)
 
-        // 执行转账签名
-        const transferPayload: {
-          chainName: string;
-          senderAddress: string;
-          receiveAddress: string;
-          balance: string;
-          assetType?: string;
-        } = {
-          chainName: chain,
-          senderAddress: from,
-          receiveAddress: to,
-          balance: amount,
-        };
-        if (asset) {
-          transferPayload.assetType = asset;
-        }
+        const unsignedTx = await provider.buildTransaction({
+          type: 'transfer',
+          from,
+          to,
+          amount: valueAmount,
+          ...(asset ? { bioAssetType: asset } : {}),
+        })
 
-        const signature = await authService.handleTransferSign(transferPayload, encryptedSecret, password);
+        const signedTx = await signUnsignedTransaction({
+          walletId,
+          password,
+          from,
+          chainId: resolvedChainId,
+          unsignedTx,
+        })
 
-        // TODO: 广播交易到链上 (需要调用 chain adapter 的 broadcastTransaction)
-        // 目前先返回签名作为 txHash 的占位符
-        const txHash = signature;
+        const txHash = await provider.broadcastTransaction(signedTx)
+        const transaction = isRecord(signedTx.data) ? signedTx.data : { data: signedTx.data }
 
-        // 发送成功事件
         const event = new CustomEvent('miniapp-transfer-confirm', {
           detail: {
             confirmed: true,
             txHash,
+            txId: txHash,
+            transaction,
           },
-        });
-        window.dispatchEvent(event);
+        })
+        window.dispatchEvent(event)
 
-        pop();
-        return true;
+        pop()
+        return true
       } catch (error) {
-        return false;
+        console.error('[miniapp-transfer]', error)
+        throw error instanceof Error ? error : new Error('Transfer failed')
       } finally {
-        setIsConfirming(false);
+        setIsConfirming(false)
       }
-    });
+    })
 
-    // 打开钱包锁验证
     push('WalletLockConfirmJob', {
       title: t('confirmTransfer'),
-    });
-  }, [isConfirming, currentWallet, chain, from, to, amount, asset, pop, push, t]);
+      description: lockDescription,
+      miniappName: appName,
+      miniappIcon: appIcon,
+      walletName,
+      walletAddress: from,
+      walletChainId: resolvedChainId,
+    })
+  }, [isConfirming, walletId, resolvedChainId, from, to, amount, asset, pop, push, t, lockDescription, appName, appIcon, walletName])
 
   const handleCancel = useCallback(() => {
     const event = new CustomEvent('miniapp-transfer-confirm', {
       detail: { confirmed: false },
-    });
-    window.dispatchEvent(event);
-    pop();
-  }, [pop]);
-
-  const displayAsset = asset || chain.toUpperCase();
+    })
+    window.dispatchEvent(event)
+    pop()
+  }, [pop])
 
   return (
     <BottomSheet onCancel={handleCancel}>
       <div className="bg-background rounded-t-2xl">
-        {/* Handle */}
         <div className="flex justify-center py-3">
           <div className="bg-muted h-1 w-10 rounded-full" />
         </div>
 
-        {/* Header */}
         <MiniappSheetHeader
           title={t('confirmTransfer')}
-          description={`${appName || t('unknownDApp')} ${t('requestsTransfer')}`}
+          description={lockDescription}
           appName={appName}
           appIcon={appIcon}
           walletInfo={{
             name: walletName,
             address: from,
-            chainId: chain,
+            chainId: resolvedChainId,
           }}
         />
 
-        {/* Content */}
         <div className="space-y-4 p-4">
-          {/* Amount */}
           <div className="bg-muted/50 rounded-xl p-4 text-center">
             <AmountDisplay
               value={amount}
@@ -158,40 +170,39 @@ function MiniappTransferConfirmJobContent() {
             />
           </div>
 
-          {/* From -> To */}
           <div className="bg-muted/50 space-y-3 rounded-xl p-4">
-            {/* From */}
             <div className="flex items-center gap-3">
               <span className="text-muted-foreground w-10 shrink-0 text-xs"> {t('from')}</span>
               <AddressDisplay address={from} copyable className="flex-1 text-sm" />
             </div>
 
-            {/* Arrow */}
             <div className="flex justify-center">
               <IconArrowDown className="text-muted-foreground size-4" />
             </div>
 
-            {/* To */}
             <div className="flex items-center gap-3">
               <span className="text-muted-foreground w-10 shrink-0 text-xs"> {t('to')}</span>
               <AddressDisplay address={to} copyable className="flex-1 text-sm" />
             </div>
           </div>
 
-          {/* Chain */}
+          {!walletId && (
+            <div className="rounded-xl bg-amber-50 p-3 text-sm text-amber-800 dark:bg-amber-950/30 dark:text-amber-200">
+              {t('signingAddressNotFound')}
+            </div>
+          )}
+
           <div className="bg-muted/50 flex items-center justify-between rounded-xl p-3">
             <span className="text-muted-foreground text-sm"> {t('network')}</span>
-            <ChainBadge chainId={chain} />
+            <ChainBadge chainId={resolvedChainId} />
           </div>
 
-          {/* Warning */}
           <div className="flex items-start gap-2 rounded-xl bg-amber-50 p-3 dark:bg-amber-950/30">
             <IconAlertTriangle className="mt-0.5 size-5 shrink-0 text-amber-600" />
             <p className="text-sm text-amber-800 dark:text-amber-200">{t('transferWarning')}</p>
           </div>
         </div>
 
-        {/* Actions */}
         <div className="flex gap-3 p-4">
           <button
             onClick={handleCancel}
@@ -202,7 +213,7 @@ function MiniappTransferConfirmJobContent() {
           </button>
           <button
             onClick={handleConfirm}
-            disabled={isConfirming}
+            disabled={isConfirming || !walletId}
             className={cn(
               'flex-1 rounded-xl py-3 font-medium transition-colors',
               'bg-primary text-primary-foreground hover:bg-primary/90',
@@ -220,11 +231,10 @@ function MiniappTransferConfirmJobContent() {
           </button>
         </div>
 
-        {/* Safe area */}
         <div className="h-[env(safe-area-inset-bottom)]" />
       </div>
     </BottomSheet>
-  );
+  )
 }
 
 export const MiniappTransferConfirmJob: ActivityComponentType<MiniappTransferConfirmJobParams> = ({ params }) => {
@@ -232,5 +242,5 @@ export const MiniappTransferConfirmJob: ActivityComponentType<MiniappTransferCon
     <ActivityParamsProvider params={params}>
       <MiniappTransferConfirmJobContent />
     </ActivityParamsProvider>
-  );
-};
+  )
+}

--- a/src/stackflow/activities/sheets/__tests__/miniapp-wallet.test.ts
+++ b/src/stackflow/activities/sheets/__tests__/miniapp-wallet.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { walletStore } from '@/stores'
+import {
+  findMiniappWalletByAddress,
+  findMiniappWalletIdByAddress,
+  resolveMiniappChainId,
+} from '../miniapp-wallet'
+
+describe('miniapp-wallet matcher', () => {
+  beforeEach(() => {
+    walletStore.setState(() => ({
+      wallets: [
+        {
+          id: 'wallet-1',
+          name: 'Wallet 1',
+          address: '0xAbCd000000000000000000000000000000000000',
+          chain: 'ethereum',
+          chainAddresses: [
+            {
+              chain: 'ethereum',
+              address: '0xAbCd000000000000000000000000000000000000',
+              publicKey: '0xpub1',
+            },
+            {
+              chain: 'bfmetav2',
+              address: 'b_sender_1',
+              publicKey: 'pub-bf-1',
+            },
+          ],
+          createdAt: 1,
+          themeHue: 30,
+        },
+      ],
+      currentWalletId: 'wallet-1',
+      selectedChain: 'bfmetav2',
+      chainPreferences: {},
+      isLoading: false,
+      isInitialized: true,
+      migrationRequired: false,
+    }))
+  })
+
+  it('normalizes chain id to keyapp format', () => {
+    expect(resolveMiniappChainId(' BFMetaV2 ')).toBe('bfmetav2')
+    expect(resolveMiniappChainId('bfmeta-v2')).toBe('bfmetav2')
+  })
+
+  it('matches chain id case-insensitively', () => {
+    const result = findMiniappWalletByAddress('ETHEREUM', '0xAbCd000000000000000000000000000000000000')
+    expect(result?.wallet.id).toBe('wallet-1')
+  })
+
+  it('matches hex address case-insensitively', () => {
+    const result = findMiniappWalletByAddress('ethereum', '0xabcd000000000000000000000000000000000000')
+    expect(result?.wallet.id).toBe('wallet-1')
+  })
+
+  it('matches after trimming chain and address', () => {
+    const result = findMiniappWalletByAddress(' BFMetaV2 ', ' b_sender_1 ')
+    expect(result?.wallet.id).toBe('wallet-1')
+  })
+
+  it('returns wallet id helper result', () => {
+    expect(findMiniappWalletIdByAddress('ethereum', '0xabcd000000000000000000000000000000000000')).toBe('wallet-1')
+  })
+
+  it('returns null when wallet not found', () => {
+    expect(findMiniappWalletByAddress('ethereum', '0x0000000000000000000000000000000000000000')).toBeNull()
+    expect(findMiniappWalletIdByAddress('tron', 'T123')).toBeNull()
+  })
+})

--- a/src/stackflow/activities/sheets/miniapp-wallet.ts
+++ b/src/stackflow/activities/sheets/miniapp-wallet.ts
@@ -1,0 +1,82 @@
+import { walletStore, type ChainAddress, type Wallet } from '@/stores'
+import { chainConfigSelectors, chainConfigStore } from '@/stores/chain-config'
+
+export interface MiniappWalletMatch {
+  wallet: Wallet
+  chainAddress: ChainAddress
+}
+
+const CHAIN_ALIAS_MAP: Record<string, string> = {
+  'bfmeta-v2': 'bfmetav2',
+  'bfmeta_v2': 'bfmetav2',
+}
+
+function normalizeChainId(chainId: string): string {
+  return chainId.trim().toLowerCase()
+}
+
+function normalizeAddressForCompare(address: string): string {
+  return address.trim()
+}
+
+function isHexLikeAddress(address: string): boolean {
+  return address.startsWith('0x')
+}
+
+function isSameChainId(left: string, right: string): boolean {
+  return normalizeChainId(left) === normalizeChainId(right)
+}
+
+function isSameAddress(left: string, right: string): boolean {
+  const normalizedLeft = normalizeAddressForCompare(left)
+  const normalizedRight = normalizeAddressForCompare(right)
+
+  if (isHexLikeAddress(normalizedLeft) || isHexLikeAddress(normalizedRight)) {
+    return normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+  }
+  return normalizedLeft === normalizedRight
+}
+
+/**
+ * 解析 miniapp 传入的 chainId，返回 KeyApp 内部规范 chainId。
+ */
+export function resolveMiniappChainId(chainId: string): string {
+  const normalizedChainId = normalizeChainId(chainId)
+  if (normalizedChainId.length === 0) return normalizedChainId
+
+  const snapshot = chainConfigStore.state
+  const config = chainConfigSelectors.getChainById(snapshot, normalizedChainId)
+  if (config) {
+    return config.id
+  }
+
+  return CHAIN_ALIAS_MAP[normalizedChainId] ?? normalizedChainId
+}
+
+/**
+ * 按链和地址查找对应钱包。
+ */
+export function findMiniappWalletByAddress(chainId: string, address: string): MiniappWalletMatch | null {
+  const resolvedChainId = resolveMiniappChainId(chainId)
+
+  for (const wallet of walletStore.state.wallets) {
+    const chainAddress = wallet.chainAddresses.find((candidate) => {
+      return isSameChainId(candidate.chain, resolvedChainId) && isSameAddress(candidate.address, address)
+    })
+    if (chainAddress) {
+      return {
+        wallet,
+        chainAddress,
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * 按链和地址查找对应钱包 ID。
+ */
+export function findMiniappWalletIdByAddress(chainId: string, address: string): string | null {
+  return findMiniappWalletByAddress(chainId, address)?.wallet.id ?? null
+}


### PR DESCRIPTION
Closes #410

## Summary
- fix miniapp authorization popup context consistency (app icon + wallet + chain)
- fix WalletLock confirm sheet header consistency for miniapp risk operations
- normalize chain id resolution for miniapp signing/transfer pipeline (incl. BFMetaV2 alias)
- add compatibility tests for transfer handler + miniapp wallet chain normalization
- optimize monochrome-mask: built-in hooks avoid runtime dynamic compile and mask generation is idle-scheduled

## Verification
- pnpm agent review verify
- pnpm vitest run src/services/ecosystem/__tests__/transfer-handler.test.ts src/stackflow/activities/sheets/__tests__/miniapp-wallet.test.ts
- pnpm vitest run src/components/security/pattern-lock.test.tsx src/components/security/pattern-lock-setup.test.tsx src/services/authorize/__tests__/integration.test.tsx