### PR TITLE
Desktop beta app name uses destructive tint

### DIFF
--- a/src/components/ecosystem/my-apps-page.module.css
+++ b/src/components/ecosystem/my-apps-page.module.css
@@ -103,3 +103,9 @@
   opacity: 0;
   transform: scale(0.9) translateY(4px);
 }
+
+/* beta miniapp：桌面图标名称带轻微“危险色”提示 */
+.betaAppName {
+  color: color-mix(in oklab, var(--foreground) 88%, var(--destructive) 12%);
+  opacity: 0.9;
+}

--- a/src/components/ecosystem/my-apps-page.tsx
+++ b/src/components/ecosystem/my-apps-page.tsx
@@ -328,26 +328,6 @@ function IOSDesktopIcon({ app, onTap, onOpen, onDetail, onRemove }: IOSDesktopIc
                 borderRadius: 16,
               }}
             >
-              {app.beta && (
-                <div className="pointer-events-none absolute -top-1 -left-1" aria-hidden="true">
-                  <div
-                    className={cn(
-                      'ring-background ring-2',
-                      'flex items-center justify-center rounded-full',
-                      'bg-amber-500 text-white',
-                    )}
-                    style={{
-                      width: 18,
-                      height: 18,
-                      fontSize: 11,
-                      fontWeight: 700,
-                    }}
-                  >
-                    β
-                  </div>
-                </div>
-              )}
-
               <motion.div
                 {...(sharedLayoutIds
                   ? {
@@ -425,7 +405,12 @@ function IOSDesktopIcon({ app, onTap, onOpen, onDetail, onRemove }: IOSDesktopIc
       </div>
 
       {/* label：永远处于静态布局（不进入 popover top-layer），避免启动动画把文字一起“拎走” */}
-      <span className="text-foreground/90 line-clamp-2 max-w-[72px] text-center text-[11px] leading-tight font-medium">
+      <span
+        className={cn(
+          app.beta ? styles.betaAppName : 'text-foreground/90',
+          'line-clamp-2 max-w-[72px] text-center text-[11px] leading-tight font-medium',
+        )}
+      >
         {app.name}
       </span>
     </div>


### PR DESCRIPTION
Closes #418\n\n## What\n- Beta miniapps show a subtle destructive-tinted name on the desktop\n\n## Notes\n- Uses CSS color-mix() with theme vars (foreground/destructive)