### PR TITLE
fix(ecosystem): fifo miniapp sheets + tx object result

### DIFF
--- a/src/services/chain-adapter/providers/provider-cache.test.ts
+++ b/src/services/chain-adapter/providers/provider-cache.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import 'fake-indexeddb/auto'
+
+import { resetChainConfigStorageForTests } from '@/services/chain-config/storage'
+import { chainConfigActions, chainConfigStore } from '@/stores/chain-config'
+
+import { clearProviderCache, getChainProvider } from './index'
+
+describe('getChainProvider cache safety', () => {
+  beforeEach(async () => {
+    await resetChainConfigStorageForTests()
+    clearProviderCache()
+    chainConfigStore.setState(() => ({
+      snapshot: null,
+      isLoading: false,
+      error: null,
+      migrationRequired: false,
+    }))
+  })
+
+  it('does not cache an empty provider before chain configs initialize', async () => {
+    const provider1 = getChainProvider('bfmetav2')
+    const provider2 = getChainProvider('bfmetav2')
+
+    expect(provider1).not.toBe(provider2)
+    expect(provider1.supportsFullTransaction).toBe(false)
+
+    await chainConfigActions.initialize()
+
+    const provider3 = getChainProvider('bfmetav2')
+    const provider4 = getChainProvider('bfmetav2')
+
+    expect(provider3).toBe(provider4)
+    expect(provider3).not.toBe(provider1)
+    expect(provider3.supportsFullTransaction).toBe(true)
+  })
+
+  it('rebuilds the cached provider when api entries change', async () => {
+    await chainConfigActions.initialize()
+
+    const originalSnapshot = chainConfigStore.state.snapshot
+    expect(originalSnapshot).not.toBeNull()
+    if (!originalSnapshot) return
+
+    const originalConfig = originalSnapshot.configs.find((config) => config.id === 'bfmetav2')
+    expect(originalConfig).toBeTruthy()
+    if (!originalConfig) return
+
+    chainConfigStore.setState((state) => {
+      const snapshot = state.snapshot
+      if (!snapshot) return state
+
+      return {
+        ...state,
+        snapshot: {
+          ...snapshot,
+          configs: snapshot.configs.map((config) =>
+            config.id === originalConfig.id
+              ? {
+                  ...config,
+                  apis: [],
+                }
+              : config,
+          ),
+        },
+      }
+    })
+
+    clearProviderCache()
+
+    const provider1 = getChainProvider('bfmetav2')
+    expect(provider1.supportsFullTransaction).toBe(false)
+
+    chainConfigStore.setState((state) => {
+      const snapshot = state.snapshot
+      if (!snapshot) return state
+
+      return {
+        ...state,
+        snapshot: {
+          ...snapshot,
+          configs: snapshot.configs.map((config) =>
+            config.id === originalConfig.id ? originalConfig : config,
+          ),
+        },
+      }
+    })
+
+    const provider2 = getChainProvider('bfmetav2')
+    expect(provider2).not.toBe(provider1)
+    expect(provider2.supportsFullTransaction).toBe(true)
+  })
+})
+

--- a/src/services/ecosystem/handlers/destroy.ts
+++ b/src/services/ecosystem/handlers/destroy.ts
@@ -5,6 +5,7 @@
 import type { MethodHandler, EcosystemDestroyParams } from '../types'
 import { BioErrorCodes } from '../types'
 import { HandlerContext, type MiniappInfo, toMiniappInfo } from './context'
+import { enqueueMiniappSheet } from '../sheet-queue'
 
 // 兼容旧 API
 let _showDestroyDialog: ((params: EcosystemDestroyParams & { app: MiniappInfo }) => Promise<{ txHash: string } | null>) | null = null
@@ -43,7 +44,7 @@ export const handleDestroyAsset: MethodHandler = async (params, context) => {
     app: toMiniappInfo(context),
   }
 
-  const result = await showDestroyDialog(destroyParams)
+  const result = await enqueueMiniappSheet(context.appId, () => showDestroyDialog(destroyParams))
 
   if (!result) {
     throw Object.assign(new Error('User rejected'), { code: BioErrorCodes.USER_REJECTED })

--- a/src/services/ecosystem/handlers/transaction.ts
+++ b/src/services/ecosystem/handlers/transaction.ts
@@ -8,6 +8,7 @@
 import type { MethodHandler, EcosystemTransferParams, UnsignedTransaction, SignedTransaction } from '../types'
 import { BioErrorCodes } from '../types'
 import { HandlerContext, type SignTransactionParams, toMiniappInfo } from './context'
+import { enqueueMiniappSheet } from '../sheet-queue'
 
 import { Amount } from '@/types/amount'
 import { chainConfigActions, chainConfigSelectors, chainConfigStore, walletStore } from '@/stores'
@@ -166,12 +167,14 @@ export const handleSignTransaction: MethodHandler = async (params, context) => {
     throw Object.assign(new Error('SignTransaction dialog not available'), { code: BioErrorCodes.INTERNAL_ERROR })
   }
 
-  const result = await showDialog({
-    from: opts.from,
-    chain: opts.chain,
-    unsignedTx: opts.unsignedTx,
-    app: toMiniappInfo(context),
-  })
+  const result = await enqueueMiniappSheet(context.appId, () =>
+    showDialog({
+      from: opts.from,
+      chain: opts.chain,
+      unsignedTx: opts.unsignedTx,
+      app: toMiniappInfo(context),
+    }),
+  )
 
   if (!result) {
     throw Object.assign(new Error('User rejected'), { code: BioErrorCodes.USER_REJECTED })

--- a/src/services/ecosystem/handlers/transfer.ts
+++ b/src/services/ecosystem/handlers/transfer.ts
@@ -5,6 +5,7 @@
 import type { MethodHandler, EcosystemTransferParams } from '../types'
 import { BioErrorCodes } from '../types'
 import { HandlerContext, type MiniappInfo, type TransferDialogResult, toMiniappInfo } from './context'
+import { enqueueMiniappSheet } from '../sheet-queue'
 
 // 兼容旧 API
 let _showTransferDialog: ((params: EcosystemTransferParams & { app: MiniappInfo }) => Promise<TransferDialogResult | null>) | null = null
@@ -74,7 +75,7 @@ export const handleSendTransaction: MethodHandler = async (params, context) => {
     transferParams.tokenAddress = opts.tokenAddress
   }
 
-  const result = await showTransferDialog(transferParams)
+  const result = await enqueueMiniappSheet(context.appId, () => showTransferDialog(transferParams))
 
   if (!result) {
     throw Object.assign(new Error('User rejected'), { code: BioErrorCodes.USER_REJECTED })

--- a/src/services/ecosystem/handlers/tron.ts
+++ b/src/services/ecosystem/handlers/tron.ts
@@ -8,6 +8,7 @@
 import type { MethodHandler, BioAccount } from '../types'
 import { BioErrorCodes } from '../types'
 import { HandlerContext, type TronTransaction, type MiniappInfo } from './context'
+import { enqueueMiniappSheet } from '../sheet-queue'
 
 // Re-export for convenience
 export type { TronTransaction } from './context'
@@ -90,7 +91,9 @@ export const handleTronRequestAccounts: MethodHandler = async (_params, context)
     throw Object.assign(new Error('Wallet picker not available'), { code: BioErrorCodes.INTERNAL_ERROR })
   }
 
-  const wallet = await showWalletPicker({ app: { name: context.appName, icon: context.appIcon } })
+  const wallet = await enqueueMiniappSheet(context.appId, () =>
+    showWalletPicker({ app: { name: context.appName, icon: context.appIcon } }),
+  )
   if (!wallet) {
     throw Object.assign(new Error('User rejected'), { code: BioErrorCodes.USER_REJECTED })
   }
@@ -140,10 +143,12 @@ export const handleTronSignTransaction: MethodHandler = async (params, context) 
     throw Object.assign(new Error('Signing dialog not available'), { code: BioErrorCodes.INTERNAL_ERROR })
   }
 
-  const result = await showSigningDialog({
-    transaction,
-    appName: context.appName,
-  })
+  const result = await enqueueMiniappSheet(context.appId, () =>
+    showSigningDialog({
+      transaction,
+      appName: context.appName,
+    }),
+  )
 
   if (!result) {
     throw Object.assign(new Error('User rejected'), { code: BioErrorCodes.USER_REJECTED })

--- a/src/services/ecosystem/handlers/wallet.ts
+++ b/src/services/ecosystem/handlers/wallet.ts
@@ -5,6 +5,7 @@
 import type { MethodHandler, BioAccount } from '../types'
 import { BioErrorCodes } from '../types'
 import { HandlerContext } from './context'
+import { enqueueMiniappSheet } from '../sheet-queue'
 import { getChainProvider } from '@/services/chain-adapter/providers'
 import { walletStore } from '@/stores/wallet'
 
@@ -49,10 +50,12 @@ export const handleRequestAccounts: MethodHandler = async (params, context) => {
   // 支持 chain 参数过滤钱包
   const opts = params as { chain?: string } | undefined
 
-  const wallet = await showWalletPicker({
-    chain: opts?.chain,
-    app: { name: context.appName, icon: context.appIcon },
-  })
+  const wallet = await enqueueMiniappSheet(context.appId, () =>
+    showWalletPicker({
+      chain: opts?.chain,
+      app: { name: context.appName, icon: context.appIcon },
+    }),
+  )
   if (!wallet) {
     throw Object.assign(new Error('User rejected'), { code: BioErrorCodes.USER_REJECTED })
   }
@@ -77,10 +80,12 @@ export const handleSelectAccount: MethodHandler = async (params, context) => {
   }
 
   const opts = params as { chain?: string } | undefined
-  const wallet = await showWalletPicker({
-    ...opts,
-    app: { name: context.appName, icon: context.appIcon },
-  })
+  const wallet = await enqueueMiniappSheet(context.appId, () =>
+    showWalletPicker({
+      ...opts,
+      app: { name: context.appName, icon: context.appIcon },
+    }),
+  )
   if (!wallet) {
     throw Object.assign(new Error('User rejected'), { code: BioErrorCodes.USER_REJECTED })
   }
@@ -96,10 +101,12 @@ export const handlePickWallet: MethodHandler = async (params, context) => {
   }
 
   const opts = params as { chain?: string; exclude?: string } | undefined
-  const account = await showWalletPicker({
-    ...opts,
-    app: { name: context.appName, icon: context.appIcon },
-  })
+  const account = await enqueueMiniappSheet(context.appId, () =>
+    showWalletPicker({
+      ...opts,
+      app: { name: context.appName, icon: context.appIcon },
+    }),
+  )
   if (!account) {
     throw Object.assign(new Error('User rejected'), { code: BioErrorCodes.USER_REJECTED })
   }
@@ -129,4 +136,3 @@ export const handleGetBalance: MethodHandler = async (params, _context) => {
     return '0'
   }
 }
-

--- a/src/services/ecosystem/sheet-queue.ts
+++ b/src/services/ecosystem/sheet-queue.ts
@@ -1,0 +1,39 @@
+type SheetTask<T> = () => Promise<T>
+
+const tails = new Map<string, Promise<void>>()
+
+/**
+ * Enqueue a UI sheet task for a miniapp.
+ *
+ * - FIFO per appId
+ * - Each task waits for the previous one to settle
+ * - Rejections do not break the queue
+ */
+export function enqueueMiniappSheet<T>(appId: string, task: SheetTask<T>): Promise<T> {
+  const previous = tails.get(appId) ?? Promise.resolve()
+
+  const run = previous
+    .catch(() => undefined)
+    .then(task)
+
+  const nextTail = run.then(
+    () => undefined,
+    () => undefined,
+  )
+
+  tails.set(appId, nextTail)
+
+  void nextTail.finally(() => {
+    if (tails.get(appId) === nextTail) {
+      tails.delete(appId)
+    }
+  })
+
+  return run
+}
+
+/** @internal For tests only. */
+export function __clearMiniappSheetQueueForTests(): void {
+  tails.clear()
+}
+

--- a/src/stackflow/components/TabBar.tsx
+++ b/src/stackflow/components/TabBar.tsx
@@ -286,10 +286,10 @@ export function TabBar({ activeTab, onTabChange, className }: TabBarProps) {
                 key={tab.id}
                 hasRunningApps={hasRunningApps}
                 onSwipeUp={handleEcosystemSwipeUp}
+                onTap={handleEcosystemClick}
                 className={buttonClassName}
               >
                 <button
-                  onClick={handleEcosystemClick}
                   data-testid={`tab-${tab.id}`}
                   className="flex flex-1 flex-col items-center justify-center gap-1"
                   aria-label={label}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,9 +1,13 @@
 import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
 import { afterEach, vi } from 'vitest'
+import 'fake-indexeddb/auto'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+
+// Ensure the default i18n instance is initialized for hooks like useTranslation.
+import '@/i18n'
 
 // Mock @number-flow/react for tests (doesn't work in JSDOM)
 vi.mock('@number-flow/react', () => ({


### PR DESCRIPTION
Closes #425

## Changes
- Enforce FIFO miniapp sheets per appId via queue
- Normalize `bio_sendTransaction` result to always include an object `transaction`
- Avoid poisoning ChainProvider cache before chain config init (with tests)
- Fix ecosystem tab swipe-up vs tap double-trigger
- Document state-first workflow in `AGENTS.md`

## Verification
- `pnpm agent review verify`
