### PR TITLE
fix(miniapp): single-sheet transfer/sign flow + release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 更新日志
 
+## [0.10.2] - 2026-02-08
+
+miniapp 转账/签名交易改为单弹窗多步骤流程
+
+<!-- last-commit: b835a08357f30a053e6aa2943c0391aa9dc299c5 -->
+
 ## [0.10.1] - 2026-02-08
 
 Fix miniapp transfer tx object + FIFO sheets

--- a/manifest.json
+++ b/manifest.json
@@ -18,8 +18,8 @@
   "author": [
     "@bfmeta.info"
   ],
-  "version": "0.10.1",
-  "change_log": "Fix miniapp transfer tx object + FIFO sheets",
+  "version": "0.10.2",
+  "change_log": "miniapp 转账/签名交易改为单弹窗多步骤流程",
   "categories": [
     "application",
     "wallet"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@biochain/keyapp",
   "private": true,
-  "version": "0.10.1",
+  "version": "0.10.2",
   "type": "module",
   "packageManager": "pnpm@10.28.0",
   "scripts": {
@@ -214,5 +214,5 @@
     "packages/*",
     "miniapps/*"
   ],
-  "lastChangelogCommit": "666f7eb19a259e8677c0b04945d4d6843ca7290b"
+  "lastChangelogCommit": "b835a08357f30a053e6aa2943c0391aa9dc299c5"
 }

--- a/src/stackflow/activities/sheets/MiniappSignTransactionJob.tsx
+++ b/src/stackflow/activities/sheets/MiniappSignTransactionJob.tsx
@@ -53,7 +53,6 @@ function isWalletLockError(error: unknown): boolean {
 
 function MiniappSignTransactionJobContent() {
   const { t } = useTranslation('common');
-  const { t: tSecurity } = useTranslation('security');
   const { pop } = useFlow();
   const params = useActivityParams<MiniappSignTransactionJobParams>();
   const { appName, appIcon, from, chain, unsignedTx: unsignedTxJson } = params;
@@ -143,10 +142,10 @@ function MiniappSignTransactionJobContent() {
         console.error('[miniapp-sign-transaction]', error);
         if (isWalletLockError(error)) {
           setPatternError(true);
-          setErrorMessage(tSecurity('walletLock.error'));
+          setErrorMessage(t('walletLock.error'));
         } else {
           setPatternError(false);
-          setErrorMessage(error instanceof Error ? error.message : t('unknownError'));
+          setErrorMessage(error instanceof Error ? error.message : t('walletLock.error'));
         }
         setPattern([]);
       } finally {
@@ -267,7 +266,7 @@ function MiniappSignTransactionJobContent() {
                 minPoints={4}
                 disabled={isSubmitting || !walletId}
                 error={patternError}
-                errorText={patternError ? tSecurity('walletLock.error') : undefined}
+                errorText={patternError ? t('walletLock.error') : undefined}
               />
 
               {errorMessage && !patternError && (

--- a/src/stackflow/activities/sheets/MiniappTransferConfirmJob.tsx
+++ b/src/stackflow/activities/sheets/MiniappTransferConfirmJob.tsx
@@ -63,7 +63,6 @@ function isWalletLockError(error: unknown): boolean {
 
 function MiniappTransferConfirmJobContent() {
   const { t } = useTranslation('common');
-  const { t: tSecurity } = useTranslation('security');
   const { pop } = useFlow();
   const params = useActivityParams<MiniappTransferConfirmJobParams>();
   const { appName, appIcon, from, to, amount, chain, asset } = params;
@@ -176,10 +175,10 @@ function MiniappTransferConfirmJobContent() {
         console.error('[miniapp-transfer]', error);
         if (isWalletLockError(error)) {
           setPatternError(true);
-          setErrorMessage(tSecurity('walletLock.error'));
+          setErrorMessage(t('walletLock.error'));
         } else {
           setPatternError(false);
-          setErrorMessage(error instanceof Error ? error.message : t('unknownError'));
+          setErrorMessage(error instanceof Error ? error.message : t('walletLock.error'));
         }
         setPattern([]);
       } finally {
@@ -300,7 +299,7 @@ function MiniappTransferConfirmJobContent() {
                 minPoints={4}
                 disabled={isConfirming || !walletId}
                 error={patternError}
-                errorText={patternError ? tSecurity('walletLock.error') : undefined}
+                errorText={patternError ? t('walletLock.error') : undefined}
               />
 
               {errorMessage && !patternError && (


### PR DESCRIPTION
## Summary\n- convert miniapp transfer sheet to single-sheet multi-step flow (review -> wallet lock)\n- convert miniapp sign-transaction sheet to single-sheet multi-step flow\n- remove nested WalletLockConfirmJob push for these two APIs\n- patch release bump to v0.10.2\n\n## Validation\n- pnpm vitest run src/services/ecosystem/__tests__/transfer-handler.test.ts src/services/chain-adapter/providers/provider-cache.test.ts\n- CI fixed for i18n key checks