### PR TITLE
fix: harden docs webapp links and default GitHub Pages host

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,7 +87,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CHANNEL: ${{ steps.channel.outputs.channel }}
           VITEPRESS_BASE: ${{ vars.VITEPRESS_BASE || format('/{0}/', github.event.repository.name) }}
-          SITE_ORIGIN: ${{ vars.SITE_ORIGIN || format('https://{0}.github.io', github.repository_owner) }}
+          SITE_ORIGIN: ${{ format('https://{0}.github.io', github.repository_owner) }}
           VITE_DEV_MODE: ${{ steps.channel.outputs.channel == 'beta' && 'true' || 'false' }}
         run: |
           pnpm install --frozen-lockfile
@@ -129,6 +129,11 @@ jobs:
               cp -r dist-web/* docs/public/webapp/
             fi
           fi
+
+          # 生成 Web ZIP 下载文件（供 download 页面直接下载）
+          rm -f docs/public/webapp/bfmpay-web.zip docs/public/webapp-dev/bfmpay-web-beta.zip
+          (cd docs/public/webapp && zip -qr bfmpay-web.zip . -x "*.zip")
+          (cd docs/public/webapp-dev && zip -qr bfmpay-web-beta.zip . -x "*.zip")
           
           # 构建 Storybook
           pnpm build-storybook
@@ -602,6 +607,11 @@ jobs:
             fi
           fi
 
+          # 生成 Web ZIP 下载文件（供 download 页面直接下载）
+          rm -f docs/public/webapp/bfmpay-web.zip docs/public/webapp-dev/bfmpay-web-beta.zip
+          (cd docs/public/webapp && zip -qr bfmpay-web.zip . -x "*.zip")
+          (cd docs/public/webapp-dev && zip -qr bfmpay-web-beta.zip . -x "*.zip")
+
           # 显示准备好的目录
           echo "=== webapp directory ==="
           ls -la docs/public/webapp/ | head -5
@@ -623,7 +633,7 @@ jobs:
       - name: Build VitePress site
         env:
           VITEPRESS_BASE: ${{ vars.VITEPRESS_BASE || format('/{0}/', github.event.repository.name) }}
-          SITE_ORIGIN: ${{ vars.SITE_ORIGIN || format('https://{0}.github.io', github.repository_owner) }}
+          SITE_ORIGIN: ${{ format('https://{0}.github.io', github.repository_owner) }}
         run: |
           echo "Building with VITEPRESS_BASE=$VITEPRESS_BASE"
           pnpm docs:build
@@ -633,7 +643,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VITEPRESS_BASE: ${{ vars.VITEPRESS_BASE || format('/{0}/', github.event.repository.name) }}
-          SITE_ORIGIN: ${{ vars.SITE_ORIGIN || format('https://{0}.github.io', github.repository_owner) }}
+          SITE_ORIGIN: ${{ format('https://{0}.github.io', github.repository_owner) }}
         run: |
           # VitePress 输出目录
           mkdir -p gh-pages

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -70,29 +70,21 @@ KeyApp/
 
 ### GitHub Pages 部署
 
-Fork 本项目后，可以通过 **仓库变量** 自定义部署配置，无需修改任何代码。
+Fork 本项目后，默认部署到 `https://{owner}.github.io/{repo}/`，通常无需额外改动。
 
-#### 配置步骤
+#### 默认行为
 
-1. Fork 本仓库
-2. 进入仓库 Settings → Secrets and variables → Actions → Variables
-3. 添加以下变量（按需）：
+- 默认站点：`https://{owner}.github.io/{repo}/`
+- 默认 Base Path：`/{repo_name}/`（如 `/KeyApp/`）
+- `SITE_ORIGIN` / `SITE_BASE_URL` 为可选覆盖项，未设置时自动按仓库推导
+
+#### 可选配置
+
+如果确实需要覆盖路径，可在仓库 Variables 设置：
 
 | 变量名 | 说明 | 示例值 |
 |--------|------|--------|
 | `VITEPRESS_BASE` | 站点 base path | `/` 或 `/my-app/` |
-
-#### 默认行为
-
-如果不设置 `VITEPRESS_BASE` 变量，默认使用 `/{repo_name}/`（如 `/KeyApp/`）。
-
-#### 自定义域名
-
-使用自定义域名时，设置 `VITEPRESS_BASE=/`：
-
-1. 添加仓库变量 `VITEPRESS_BASE` 值为 `/`
-2. 在 DNS 提供商配置 CNAME 记录指向 `{username}.github.io`
-3. 在仓库 Settings → Pages 中配置自定义域名
 
 ### 构建产物
 

--- a/docs/download.md
+++ b/docs/download.md
@@ -13,7 +13,8 @@
       <h3>Web 稳定版</h3>
     </div>
     <p>经过充分测试的稳定版本，推荐日常使用。</p>
-    <a href="./webapp/" class="download-btn">打开 Web 应用</a>
+    <a href="./webapp/" class="download-btn" target="_blank" rel="noreferrer">打开 Web 应用</a>
+    <a href="./webapp/bfmpay-web.zip" class="download-link">下载 ZIP 文件</a>
   </div>
   
   <div class="download-card">
@@ -22,7 +23,8 @@
       <h3>Web 测试版</h3>
     </div>
     <p>包含最新功能，每次代码更新自动发布。</p>
-    <a href="./webapp-dev/" class="download-btn secondary">打开 Beta 版</a>
+    <a href="./webapp-dev/" class="download-btn secondary" target="_blank" rel="noreferrer">打开 Beta 版</a>
+    <a href="./webapp-dev/bfmpay-web-beta.zip" class="download-link">下载 ZIP 文件</a>
   </div>
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ hero:
     - theme: brand
       text: 立即使用
       link: ./webapp/
-      target: _self
+      target: _blank
     - theme: alt
       text: 下载安装
       link: ./download
@@ -41,7 +41,7 @@ features:
 
 ## 快速开始
 
-1. 访问 <a href="./webapp/" target="_self">Web 应用</a> 或 [下载 DWEB 版本](./download)
+1. 访问 <a href="./webapp/" target="_blank" rel="noreferrer">Web 应用</a> 或 [下载 DWEB 版本](./download)
 2. 创建新钱包或导入已有钱包
 3. 开始管理您的数字资产
 
@@ -49,7 +49,7 @@ features:
 
 | 平台 | 稳定版 | 测试版 |
 |------|--------|--------|
-| **Web** | <a href="./webapp/" target="_self">webapp/</a> | <a href="./webapp-dev/" target="_self">webapp-dev/</a> |
+| **Web** | <a href="./webapp/" target="_blank" rel="noreferrer">webapp/</a> | <a href="./webapp-dev/" target="_blank" rel="noreferrer">webapp-dev/</a> |
 | **DWEB** | [下载页面](./download) | [下载页面](./download) |
 
 查看 [下载页面](./download) 了解更多版本信息。

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -140,14 +140,29 @@ function copyDirContents(src: string, dest: string) {
   }
 }
 
-function resolveSiteOrigin(): string | null {
-  return process.env.DWEB_SITE_ORIGIN ?? process.env.VITEPRESS_SITE_ORIGIN ?? process.env.SITE_ORIGIN ?? null
+function resolveGitHubPagesDefaults() {
+  const repository = process.env.GITHUB_REPOSITORY ?? 'BioforestChain/KeyApp'
+  const [owner = 'BioforestChain', repo = 'KeyApp'] = repository.split('/')
+  return {
+    owner,
+    repo,
+    siteOrigin: `https://${owner}.github.io`,
+    siteBasePath: `/${repo}/`,
+  }
 }
 
-function resolveSiteBaseUrl(): string | null {
+function resolveSiteOrigin(): string {
+  return (
+    process.env.DWEB_SITE_ORIGIN ??
+    process.env.VITEPRESS_SITE_ORIGIN ??
+    process.env.SITE_ORIGIN ??
+    resolveGitHubPagesDefaults().siteOrigin
+  )
+}
+
+function resolveSiteBaseUrl(): string {
   const origin = resolveSiteOrigin()
-  if (!origin) return null
-  const basePath = process.env.SITE_BASE_URL ?? process.env.VITEPRESS_BASE ?? '/'
+  const basePath = process.env.SITE_BASE_URL ?? process.env.VITEPRESS_BASE ?? resolveGitHubPagesDefaults().siteBasePath
   return new URL(basePath, origin).toString()
 }
 

--- a/scripts/env-registry.json
+++ b/scripts/env-registry.json
@@ -5,26 +5,35 @@
       "key": "SITE_ORIGIN",
       "label": "KeyApp 站点 Origin",
       "type": "url",
-      "required": true,
-      "targets": { "local": true, "github": "variable" },
+      "required": false,
+      "targets": {
+        "local": true,
+        "github": "variable"
+      },
       "mask": "tail",
-      "description": "DWEB 自动更新使用的官网域名（需与 SITE_BASE_URL 成对配置）"
+      "description": "可选：DWEB 更新官网域名。默认自动使用 https://{owner}.github.io"
     },
     {
       "key": "SITE_BASE_URL",
       "label": "KeyApp 站点 Base Path",
       "type": "string",
-      "required": true,
-      "targets": { "local": true, "github": "variable" },
+      "required": false,
+      "targets": {
+        "local": true,
+        "github": "variable"
+      },
       "mask": "tail",
-      "description": "DWEB 自动更新使用的站点路径（需与 SITE_ORIGIN 成对配置，例如 /KeyApp/）"
+      "description": "可选：DWEB 更新站点路径。默认自动使用 /{repo}/"
     },
     {
       "key": "DWEB_SFTP_URL",
       "label": "DWEB SFTP 地址",
       "type": "url",
       "required": false,
-      "targets": { "local": true, "github": "variable" },
+      "targets": {
+        "local": true,
+        "github": "variable"
+      },
       "mask": "tail"
     },
     {
@@ -32,7 +41,10 @@
       "label": "DWEB SFTP 用户名 (正式)",
       "type": "string",
       "required": true,
-      "targets": { "local": true, "github": "secret" },
+      "targets": {
+        "local": true,
+        "github": "secret"
+      },
       "mask": "tail"
     },
     {
@@ -40,7 +52,10 @@
       "label": "DWEB SFTP 密码 (正式)",
       "type": "password",
       "required": true,
-      "targets": { "local": true, "github": "secret" },
+      "targets": {
+        "local": true,
+        "github": "secret"
+      },
       "mask": "hidden"
     },
     {
@@ -48,7 +63,10 @@
       "label": "DWEB SFTP 用户名 (开发)",
       "type": "string",
       "required": false,
-      "targets": { "local": true, "github": "secret" },
+      "targets": {
+        "local": true,
+        "github": "secret"
+      },
       "mask": "tail"
     },
     {
@@ -56,7 +74,10 @@
       "label": "DWEB SFTP 密码 (开发)",
       "type": "password",
       "required": false,
-      "targets": { "local": true, "github": "secret" },
+      "targets": {
+        "local": true,
+        "github": "secret"
+      },
       "mask": "hidden"
     },
     {
@@ -64,7 +85,10 @@
       "label": "E2E 测试助记词",
       "type": "string",
       "required": false,
-      "targets": { "local": true, "github": "secret" },
+      "targets": {
+        "local": true,
+        "github": "secret"
+      },
       "mask": "hidden"
     },
     {
@@ -72,7 +96,10 @@
       "label": "E2E 安全密码",
       "type": "password",
       "required": false,
-      "targets": { "local": true, "github": "secret" },
+      "targets": {
+        "local": true,
+        "github": "secret"
+      },
       "mask": "hidden"
     },
     {
@@ -80,7 +107,10 @@
       "label": "TronGrid API Key",
       "type": "password",
       "required": false,
-      "targets": { "local": true, "github": "secret" },
+      "targets": {
+        "local": true,
+        "github": "secret"
+      },
       "mask": "hidden"
     },
     {
@@ -88,7 +118,10 @@
       "label": "Etherscan API Key",
       "type": "password",
       "required": false,
-      "targets": { "local": true, "github": "secret" },
+      "targets": {
+        "local": true,
+        "github": "secret"
+      },
       "mask": "hidden"
     },
     {
@@ -96,7 +129,10 @@
       "label": "Moralis API Key",
       "type": "password",
       "required": false,
-      "targets": { "local": true, "github": "secret" },
+      "targets": {
+        "local": true,
+        "github": "secret"
+      },
       "mask": "hidden"
     }
   ]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -113,15 +113,19 @@ export default defineConfig(({ mode }) => {
   const etherscanApiKey = env.ETHERSCAN_API_KEY ?? process.env.ETHERSCAN_API_KEY ?? '';
   const moralisApiKey = env.MORALIS_API_KEY ?? process.env.MORALIS_API_KEY ?? '';
   const isDevBuild = (env.VITE_DEV_MODE ?? process.env.VITE_DEV_MODE) === 'true';
-  // DWEB 更新地址由 SITE_ORIGIN + SITE_BASE_URL 拼接，二者必须成对配置。
-  // 注意：这里不要误用 VITE_BASE_URL（它是构建资源的 base），否则会导致更新 URL 丢失站点路径。
-  const siteOrigin = env.SITE_ORIGIN ?? process.env.SITE_ORIGIN ?? 'https://bioforestchain.github.io/KeyApp/';
+  // DWEB 更新地址默认使用 GitHub Pages（https://{owner}.github.io/{repo}/）。
+  // 可通过 SITE_ORIGIN/SITE_BASE_URL 显式覆盖；注意不要误用 VITE_BASE_URL。
+  const githubRepository = env.GITHUB_REPOSITORY ?? process.env.GITHUB_REPOSITORY ?? 'BioforestChain/KeyApp';
+  const [githubOwner = 'BioforestChain', githubRepo = 'KeyApp'] = githubRepository.split('/');
+  const defaultSiteOrigin = `https://${githubOwner}.github.io`;
+  const defaultSiteBaseUrl = `/${githubRepo}/`;
+  const siteOrigin = env.SITE_ORIGIN ?? process.env.SITE_ORIGIN ?? defaultSiteOrigin;
   const siteBaseUrl =
     env.SITE_BASE_URL ??
     process.env.SITE_BASE_URL ??
     env.VITEPRESS_BASE ??
     process.env.VITEPRESS_BASE ??
-    BASE_URL;
+    defaultSiteBaseUrl;
 
   const buildTime = new Date();
   const pad = (value: number) => value.toString().padStart(2, '0');


### PR DESCRIPTION
## Summary
- default DWEB site origin/base to GitHub Pages (`https://{owner}.github.io/{repo}/`) when env is absent
- remove `SITE_ORIGIN` variable override in CD workflow (keep deterministic GitHub Pages host)
- generate `webapp` and `webapp-dev` zip artifacts in docs publish flow for download page
- add Web ZIP links on `download` page
- open webapp links in new tab to avoid VitePress SPA router interception/404

## Verification
- `pnpm docs:build`
- `pnpm vitest run src/lib/__tests__/dweb-update.test.ts --reporter=dot`
