### PR TITLE
fix: show source load errors instead of stale success state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ Thumbs.db
 
 # Remote miniapps (downloaded at dev/build time)
 miniapps/rwa-hub/
+miniapps/om-hub/
 
 # Playwright
 e2e/test-results/

--- a/src/stackflow/activities/SettingsSourcesActivity.tsx
+++ b/src/stackflow/activities/SettingsSourcesActivity.tsx
@@ -19,7 +19,6 @@ import {
   IconArrowLeft,
   IconLoader2,
   IconAlertCircle,
-  IconEdit,
 } from '@tabler/icons-react';
 import { ecosystemStore, ecosystemActions, type SourceRecord } from '@/stores/ecosystem';
 import { refreshSources, refreshSource } from '@/services/ecosystem/registry';
@@ -164,7 +163,7 @@ export const SettingsSourcesActivity: ActivityComponentType = () => {
     setIsRefreshing(true);
     try {
       await refreshSources();
-    } catch (e) {}
+    } catch {}
     setIsRefreshing(false);
   };
 
@@ -286,12 +285,15 @@ function SourceItem({ source, onToggle, onRemove, onEdit, isSelected }: SourceIt
   const { t } = useTranslation('common');
   const isDefault = source.url.includes('ecosystem.json');
 
-  const statusIcon = {
-    idle: null,
-    loading: <IconLoader2 className="text-muted-foreground size-3 animate-spin" />,
-    success: <IconCheck className="size-3 text-green-500" />,
-    error: <IconAlertCircle className="size-3 text-red-500" />,
-  }[source.status];
+  const hasError = source.status === 'error' || (source.status !== 'loading' && Boolean(source.errorMessage));
+  let statusIcon: React.ReactNode = null;
+  if (hasError) {
+    statusIcon = <IconAlertCircle className="size-3 text-red-500" />;
+  } else if (source.status === 'loading') {
+    statusIcon = <IconLoader2 className="text-muted-foreground size-3 animate-spin" />;
+  } else if (source.status === 'success') {
+    statusIcon = <IconCheck className="size-3 text-green-500" />;
+  }
 
   return (
     <div
@@ -320,8 +322,8 @@ function SourceItem({ source, onToggle, onRemove, onEdit, isSelected }: SourceIt
             <p className="text-muted-foreground text-xs">
               {t('sources.updatedAt', { date: new Date(source.lastUpdated).toLocaleString() })}
             </p>
-            {source.status === 'error' && source.errorMessage && (
-              <p className="truncate text-xs text-red-500">{source.errorMessage}</p>
+            {hasError && (
+              <p className="truncate text-xs text-red-500">{source.errorMessage ?? t('service.queryFailed')}</p>
             )}
           </div>
         </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,14 +18,14 @@ const remoteMiniappsConfig: RemoteMiniappConfig[] = [
     server: {
       locale: {
         metadataUrl: 'https://iweb.xin/rwahub.bfmeta.com.miniapp/metadata.json',
-        dirName: 'rwa-hub',
+        dirName: 'om-hub',
       },
       runtime: 'iframe',
     },
     build: {
       remote: {
-        name: 'RWA',
-        sourceUrl: 'https://iweb.xin/rwahub.bfmeta.com.miniapp/source.json',
+        name: 'Open Market',
+        sourceUrl: 'https://om-open.bf-meta.org/hub/source.json',
       },
       runtime: 'iframe',
     },


### PR DESCRIPTION
## Summary
- treat source fetch errors as error state even when cached payload fallback exists
- render source status with error-first priority in settings list (red icon + error copy)
- add regression test for cache-fallback-on-failure path
- include latest vite config update for `om-hub` remote source
- ignore generated `miniapps/om-hub/` directory

## Validation
- pnpm vitest run src/services/ecosystem/__tests__/registry.test.ts
- pnpm exec oxlint src/services/ecosystem/registry.ts src/stackflow/activities/SettingsSourcesActivity.tsx src/services/ecosystem/__tests__/registry.test.ts vite.config.ts
- pnpm agent review verify *(fails on existing unrelated unit-test baseline in repo)*
