### PR TITLE
fix(dweb): retry keyboard overlay setup when runtime is late

### DIFF
--- a/src/lib/dweb-keyboard-overlay.ts
+++ b/src/lib/dweb-keyboard-overlay.ts
@@ -13,6 +13,11 @@ export interface ApplyDwebKeyboardOverlayOptions {
   loadPlugins?: () => Promise<DwebPluginsModule>
 }
 
+export interface StartDwebKeyboardOverlayOptions extends ApplyDwebKeyboardOverlayOptions {
+  maxAttempts?: number
+  retryDelayMs?: number
+}
+
 async function defaultLoadPlugins(): Promise<DwebPluginsModule> {
   const moduleName = '@plaoc/plugins'
   const module = await import(/* @vite-ignore */ moduleName)
@@ -44,5 +49,45 @@ export async function applyDwebKeyboardOverlay(
   } catch (error) {
     console.warn('[dweb-keyboard-overlay] apply failed', error)
     return false
+  }
+}
+
+/**
+ * 启动键盘 overlay 应用流程（包含重试），用于规避运行时初始化时机过早导致的失效。
+ */
+export function startDwebKeyboardOverlay(
+  options: StartDwebKeyboardOverlayOptions = {},
+): () => void {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? 10)
+  const retryDelayMs = Math.max(50, options.retryDelayMs ?? 300)
+  let stopped = false
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let attempts = 0
+
+  const run = async (): Promise<void> => {
+    if (stopped) {
+      return
+    }
+
+    const applied = await applyDwebKeyboardOverlay(options)
+    attempts += 1
+
+    if (applied || stopped || attempts >= maxAttempts) {
+      return
+    }
+
+    timer = setTimeout(() => {
+      void run()
+    }, retryDelayMs)
+  }
+
+  void run()
+
+  return () => {
+    stopped = true
+    if (timer !== null) {
+      clearTimeout(timer)
+      timer = null
+    }
   }
 }

--- a/src/service-main.ts
+++ b/src/service-main.ts
@@ -3,7 +3,7 @@ import {
   installLegacyAuthorizeHashRewriter,
   rewriteLegacyAuthorizeHashInPlace,
 } from '@/services/authorize/deep-link'
-import { applyDwebKeyboardOverlay } from '@/lib/dweb-keyboard-overlay'
+import { startDwebKeyboardOverlay } from '@/lib/dweb-keyboard-overlay'
 
 export type ServiceMainCleanup = () => void
 
@@ -19,7 +19,7 @@ export function startServiceMain(): ServiceMainCleanup {
   rewriteLegacyAuthorizeHashInPlace()
 
   // DWEB: keep viewport stable when soft keyboard appears.
-  void applyDwebKeyboardOverlay()
+  const cleanupKeyboardOverlay = startDwebKeyboardOverlay()
 
   // Initialize preference side effects (i18n + RTL) as early as possible.
   preferencesActions.initialize()
@@ -37,5 +37,6 @@ export function startServiceMain(): ServiceMainCleanup {
 
   return () => {
     cleanupDeepLink()
+    cleanupKeyboardOverlay()
   }
 }


### PR DESCRIPTION
## Summary\n- keep using `virtualKeyboardPlugin.setOverlay(true)`\n- add startup retry loop to handle late dweb runtime readiness\n- cleanup retry timer on service teardown\n- extend unit tests for retry/cleanup behavior\n\n## Verification\n- pnpm vitest run --project=unit src/lib/dweb-keyboard-overlay.test.ts