### PR TITLE
fix(dweb): use proper @plaoc/plugins import and remove keyboard polling

### DIFF
--- a/src/lib/crypto/secure-storage.ts
+++ b/src/lib/crypto/secure-storage.ts
@@ -68,9 +68,7 @@ const BIOMETRIC_SUCCESS = 0;
 async function getDwebBiometric(): Promise<DwebBiometricPlugin | null> {
   if (!isDwebEnvironment()) return null;
   try {
-    // 使用变量规避 Vite 静态分析
-    const moduleName = '@plaoc/plugins';
-    const module = await import(/* @vite-ignore */ moduleName);
+    const module = await import('@plaoc/plugins');
     return module.biometricsPlugin as DwebBiometricPlugin;
   } catch {
     return null;

--- a/src/lib/dweb-keyboard-overlay.test.ts
+++ b/src/lib/dweb-keyboard-overlay.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   applyDwebKeyboardOverlay,
-  startDwebKeyboardOverlay,
   type DwebPluginsModule,
 } from './dweb-keyboard-overlay'
 
@@ -59,54 +58,5 @@ describe('dweb keyboard overlay', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1)
 
     warnSpy.mockRestore()
-  })
-
-  it('retries until dweb environment is ready', async () => {
-    vi.useFakeTimers()
-
-    const setOverlay = vi.fn<(overlay: boolean) => Promise<void>>().mockResolvedValue()
-    const loadPlugins = vi.fn<() => Promise<DwebPluginsModule>>().mockResolvedValue({
-      virtualKeyboardPlugin: { setOverlay },
-    })
-
-    let ready = false
-    const stop = startDwebKeyboardOverlay({
-      isDweb: () => ready,
-      loadPlugins,
-      maxAttempts: 4,
-      retryDelayMs: 100,
-    })
-
-    expect(loadPlugins).not.toHaveBeenCalled()
-
-    ready = true
-    await vi.advanceTimersByTimeAsync(120)
-
-    expect(loadPlugins).toHaveBeenCalledTimes(1)
-    expect(setOverlay).toHaveBeenCalledWith(true)
-
-    stop()
-    vi.useRealTimers()
-  })
-
-  it('stops retrying after cleanup', async () => {
-    vi.useFakeTimers()
-
-    const loadPlugins = vi.fn<() => Promise<DwebPluginsModule>>().mockResolvedValue({})
-    const stop = startDwebKeyboardOverlay({
-      isDweb: () => true,
-      loadPlugins,
-      maxAttempts: 10,
-      retryDelayMs: 100,
-    })
-
-    await vi.advanceTimersByTimeAsync(120)
-    expect(loadPlugins).toHaveBeenCalledTimes(2)
-
-    stop()
-    await vi.advanceTimersByTimeAsync(500)
-    expect(loadPlugins).toHaveBeenCalledTimes(2)
-
-    vi.useRealTimers()
   })
 })

--- a/src/lib/dweb-keyboard-overlay.ts
+++ b/src/lib/dweb-keyboard-overlay.ts
@@ -13,14 +13,8 @@ export interface ApplyDwebKeyboardOverlayOptions {
   loadPlugins?: () => Promise<DwebPluginsModule>
 }
 
-export interface StartDwebKeyboardOverlayOptions extends ApplyDwebKeyboardOverlayOptions {
-  maxAttempts?: number
-  retryDelayMs?: number
-}
-
 async function defaultLoadPlugins(): Promise<DwebPluginsModule> {
-  const moduleName = '@plaoc/plugins'
-  const module = await import(/* @vite-ignore */ moduleName)
+  const module = await import('@plaoc/plugins')
   return module as DwebPluginsModule
 }
 
@@ -49,45 +43,5 @@ export async function applyDwebKeyboardOverlay(
   } catch (error) {
     console.warn('[dweb-keyboard-overlay] apply failed', error)
     return false
-  }
-}
-
-/**
- * 启动键盘 overlay 应用流程（包含重试），用于规避运行时初始化时机过早导致的失效。
- */
-export function startDwebKeyboardOverlay(
-  options: StartDwebKeyboardOverlayOptions = {},
-): () => void {
-  const maxAttempts = Math.max(1, options.maxAttempts ?? 10)
-  const retryDelayMs = Math.max(50, options.retryDelayMs ?? 300)
-  let stopped = false
-  let timer: ReturnType<typeof setTimeout> | null = null
-  let attempts = 0
-
-  const run = async (): Promise<void> => {
-    if (stopped) {
-      return
-    }
-
-    const applied = await applyDwebKeyboardOverlay(options)
-    attempts += 1
-
-    if (applied || stopped || attempts >= maxAttempts) {
-      return
-    }
-
-    timer = setTimeout(() => {
-      void run()
-    }, retryDelayMs)
-  }
-
-  void run()
-
-  return () => {
-    stopped = true
-    if (timer !== null) {
-      clearTimeout(timer)
-      timer = null
-    }
   }
 }

--- a/src/providers/AppInitializer.tsx
+++ b/src/providers/AppInitializer.tsx
@@ -15,6 +15,7 @@ import { MigrationRequiredView } from '@/components/common/migration-required-vi
 import { LoadingSpinner } from '@/components/common'
 import { DwebUpdateDialog } from '@/components/common/dweb-update-dialog'
 import { dwebUpdateActions } from '@/stores/dweb-update'
+import { applyDwebKeyboardOverlay } from '@/lib/dweb-keyboard-overlay'
 
 // 立即执行：在 React 渲染之前应用缓存的主题色，避免闪烁
 initializeThemeHue()
@@ -34,6 +35,10 @@ export function AppInitializer({ children }: { children: ReactNode }) {
   const walletMigrationRequired = useWalletMigrationRequired()
   const chainConfigLoading = useChainConfigLoading()
   const walletLoading = useWalletLoading()
+
+  useEffect(() => {
+    void applyDwebKeyboardOverlay()
+  }, [])
 
   useEffect(() => {
     // 统一初始化所有需要持久化的 store

--- a/src/service-main.ts
+++ b/src/service-main.ts
@@ -3,7 +3,6 @@ import {
   installLegacyAuthorizeHashRewriter,
   rewriteLegacyAuthorizeHashInPlace,
 } from '@/services/authorize/deep-link'
-import { startDwebKeyboardOverlay } from '@/lib/dweb-keyboard-overlay'
 
 export type ServiceMainCleanup = () => void
 
@@ -17,9 +16,6 @@ export type ServiceMainCleanup = () => void
 export function startServiceMain(): ServiceMainCleanup {
   // Normalize legacy mpay-style authorize deep links before Stackflow reads URL.
   rewriteLegacyAuthorizeHashInPlace()
-
-  // DWEB: keep viewport stable when soft keyboard appears.
-  const cleanupKeyboardOverlay = startDwebKeyboardOverlay()
 
   // Initialize preference side effects (i18n + RTL) as early as possible.
   preferencesActions.initialize()
@@ -37,6 +33,5 @@ export function startServiceMain(): ServiceMainCleanup {
 
   return () => {
     cleanupDeepLink()
-    cleanupKeyboardOverlay()
   }
 }


### PR DESCRIPTION
## Summary\n- replace `@vite-ignore` dynamic import with bundler-resolved `import('@plaoc/plugins')`\n- remove keyboard overlay polling/retry logic\n- apply keyboard overlay once after frontend mount\n- keep startup/service layer clean (no keyboard timer loop)\n\n## Verification\n- pnpm vitest run --project=unit src/lib/dweb-keyboard-overlay.test.ts