### PR TITLE
fix(ecosystem): propagate miniapp remark and update keyapp dweb id

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "id": "bfmpay.bfmeta.com.dweb",
+  "id": "keyapp.bf-meta.org.dweb",
   "name": "BFM Pay",
   "short_name": "BFM Pay",
   "description": "BFM Pay - 多链钱包应用",
@@ -24,6 +24,6 @@
     "application",
     "wallet"
   ],
-  "home": "bfmpay.bfmeta.info",
-  "homepage_url": "bfmpay.bfmeta.info"
+  "home": "keyapp.bf-meta.org",
+  "homepage_url": "keyapp.bf-meta.org"
 }

--- a/packages/dweb-compat/src/signature.ts
+++ b/packages/dweb-compat/src/signature.ts
@@ -96,6 +96,7 @@ async function handleTransfer(param: {
     balance: string
     assetType?: string
     contractInfo?: { contractAddress: string; assetType: string; decimals: number | string }
+    remark?: Record<string, string>
 }): Promise<TransferResponse> {
     const result = await bioRequest<{ txHash: string; transaction?: object }>('bio_sendTransaction', {
         from: param.senderAddress,
@@ -104,6 +105,7 @@ async function handleTransfer(param: {
         chain: param.chainName,
         asset: param.assetType,
         contractInfo: param.contractInfo,
+        remark: param.remark,
     })
 
     return {
@@ -145,12 +147,14 @@ async function handleDestroy(param: {
     senderAddress: string
     assetType: string
     destoryAmount: string
+    remark?: Record<string, string>
 }): Promise<TransferResponse> {
     const result = await bioRequest<{ txId: string; transaction: object }>('bio_destroyAsset', {
-        address: param.senderAddress,
+        from: param.senderAddress,
         chain: param.chainName,
-        assetType: param.assetType,
+        asset: param.assetType,
         amount: param.destoryAmount,
+        remark: param.remark,
     })
     return result
 }

--- a/src/services/ecosystem/__tests__/destroy-handler.test.ts
+++ b/src/services/ecosystem/__tests__/destroy-handler.test.ts
@@ -39,7 +39,7 @@ describe('handleDestroyAsset amount semantics', () => {
   });
 
   it('accepts raw amount and opens dialog', async () => {
-    const dialog = vi.fn(async () => ({ txHash: 'tx-hash' }));
+    const dialog = vi.fn(async () => ({ txHash: 'tx-hash', txId: 'tx-hash', transaction: { hash: 'tx-hash' } }));
     setDestroyDialog(dialog);
 
     const result = await handleDestroyAsset(
@@ -52,11 +52,49 @@ describe('handleDestroyAsset amount semantics', () => {
       context,
     );
 
-    expect(result).toEqual({ txHash: 'tx-hash' });
+    expect(result).toEqual({
+      txHash: 'tx-hash',
+      txId: 'tx-hash',
+      transaction: { hash: 'tx-hash' },
+    });
     expect(dialog).toHaveBeenCalledWith(
       expect.objectContaining({
         amount: '1000000000',
       }),
     );
+  });
+
+  it('passes remark to destroy dialog and normalizes transaction object', async () => {
+    const dialog = vi.fn(async () => ({ txHash: 'tx-hash' }));
+    setDestroyDialog(dialog);
+
+    const result = await handleDestroyAsset(
+      {
+        from: 'b_sender',
+        amount: '1000000000',
+        chain: 'bfmeta',
+        asset: 'BFM',
+        remark: {
+          ex_type: 'exchange.purchase',
+        },
+      },
+      context,
+    );
+
+    expect(dialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remark: {
+          ex_type: 'exchange.purchase',
+        },
+      }),
+    );
+    expect(result).toEqual({
+      txHash: 'tx-hash',
+      txId: 'tx-hash',
+      transaction: {
+        txHash: 'tx-hash',
+        txId: 'tx-hash',
+      },
+    });
   });
 });

--- a/src/services/ecosystem/__tests__/transfer-handler.test.ts
+++ b/src/services/ecosystem/__tests__/transfer-handler.test.ts
@@ -19,6 +19,11 @@ const baseParams: EcosystemTransferParams = {
   chain: 'bfmeta',
 }
 
+const baseRemark = {
+  ex_type: 'exchange.purchase',
+  ex_id: 'ex-1',
+}
+
 describe('handleSendTransaction', () => {
   beforeEach(() => {
     HandlerContext.clear()
@@ -104,6 +109,36 @@ describe('handleSendTransaction', () => {
       transaction: { hash: 'tx-hash-1', type: 'AST-01', senderId: 'b_sender' },
     })
     expect(typeof (result as { transaction: unknown }).transaction).toBe('object')
+  })
+
+  it('passes remark to transfer dialog', async () => {
+    const showTransferDialog = vi.fn(async () => ({
+      txHash: 'tx-hash-ctx-icon',
+      txId: 'tx-hash-ctx-icon',
+      transaction: { hash: 'tx-hash-ctx-icon' },
+    }))
+
+    HandlerContext.register(baseContext.appId, {
+      showWalletPicker: async () => null,
+      getConnectedAccounts: () => [],
+      showSigningDialog: async () => null,
+      showTransferDialog,
+      showSignTransactionDialog: async () => null,
+    })
+
+    await handleSendTransaction(
+      {
+        ...baseParams,
+        remark: baseRemark,
+      },
+      baseContext,
+    )
+
+    expect(showTransferDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remark: baseRemark,
+      }),
+    )
   })
 
   it('keeps backward compatibility for legacy txHash-only callback', async () => {

--- a/src/services/ecosystem/handlers/context.ts
+++ b/src/services/ecosystem/handlers/context.ts
@@ -101,6 +101,16 @@ export interface TransferDialogResult {
   transaction?: Record<string, unknown>
 }
 
+/** 销毁对话框返回值 */
+export interface DestroyDialogResult {
+  /** 链上交易 ID（兼容旧字段） */
+  txHash: string
+  /** 语义化别名：交易 ID */
+  txId?: string
+  /** 可序列化交易对象（供调用方直接提交后端） */
+  transaction?: Record<string, unknown>
+}
+
 /** Handler 回调接口 */
 export interface HandlerCallbacks {
   // Bio (BioChain) callbacks
@@ -108,7 +118,7 @@ export interface HandlerCallbacks {
   getConnectedAccounts: () => BioAccount[]
   showSigningDialog: (params: SigningParams) => Promise<SigningResult | null>
   showTransferDialog: (params: EcosystemTransferParams & { app: MiniappInfo }) => Promise<TransferDialogResult | null>
-  showDestroyDialog?: (params: EcosystemDestroyParams & { app: MiniappInfo }) => Promise<{ txHash: string } | null>
+  showDestroyDialog?: (params: EcosystemDestroyParams & { app: MiniappInfo }) => Promise<DestroyDialogResult | null>
   showSignTransactionDialog: (params: SignTransactionParams) => Promise<SignedTransaction | null>
 
   // EVM (Ethereum/BSC) callbacks

--- a/src/services/ecosystem/handlers/transfer.ts
+++ b/src/services/ecosystem/handlers/transfer.ts
@@ -82,6 +82,9 @@ export const handleSendTransaction: MethodHandler = async (params, context) => {
   if (opts.tokenAddress) {
     transferParams.tokenAddress = opts.tokenAddress
   }
+  if (opts.remark) {
+    transferParams.remark = opts.remark
+  }
 
   const result = await enqueueMiniappSheet(context.appId, () => showTransferDialog(transferParams))
 

--- a/src/services/ecosystem/types.ts
+++ b/src/services/ecosystem/types.ts
@@ -67,6 +67,7 @@ export interface EcosystemDestroyParams {
   amount: string; // raw 最小单位整数字符串
   chain: string;
   asset: string;
+  remark?: Record<string, string>;
 }
 
 /** Request message from miniapp */

--- a/src/stackflow/activities/sheets/MiniappTransferConfirmJob.tsx
+++ b/src/stackflow/activities/sheets/MiniappTransferConfirmJob.tsx
@@ -54,6 +54,8 @@ type MiniappTransferConfirmJobParams = {
   chain: string;
   /** 代币 (可选) */
   asset?: string;
+  /** 业务备注（透传到交易体） */
+  remark?: Record<string, string>;
 };
 
 type TransferStep = MiniappTransferFlowStep;
@@ -109,7 +111,7 @@ function MiniappTransferConfirmJobContent() {
   const { pop } = useFlow();
   const toast = useToast();
   const params = useActivityParams<MiniappTransferConfirmJobParams>();
-  const { requestId, appName, appIcon, from, to, amount, chain, asset } = params;
+  const { requestId, appName, appIcon, from, to, amount, chain, asset, remark } = params;
   const fallbackRequestIdRef = useRef(requestId ?? `legacy-transfer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
   const effectiveRequestId = fallbackRequestIdRef.current;
 
@@ -430,6 +432,7 @@ function MiniappTransferConfirmJobContent() {
         to,
         amount: parsedAmount,
         ...(asset ? { bioAssetType: asset } : {}),
+        ...(remark ? { remark } : {}),
       });
 
       const signedTx = await signUnsignedTransaction({
@@ -460,7 +463,7 @@ function MiniappTransferConfirmJobContent() {
 
       return { txHash, transaction };
     },
-    [resolvedChainId, parsedAmount, asset, from, to, walletId],
+    [resolvedChainId, parsedAmount, asset, from, to, walletId, remark],
   );
 
   const handleTransferFailure = useCallback(


### PR DESCRIPTION
Summary:
- update manifest dweb id/home to keyapp.bf-meta.org
- propagate remark in bio_sendTransaction and bio_destroyAsset full flow
- normalize destroy result payload to txHash/txId/transaction object
- wire destroy dialog FIFO/requestId path in MainTabsActivity
- pass remark in dweb-compat signature bridge

Validation:
- pnpm vitest run --project=unit src/services/ecosystem/__tests__/transfer-handler.test.ts src/services/ecosystem/__tests__/destroy-handler.test.ts src/stackflow/activities/sheets/MiniappConfirmJobs.regression.test.tsx
- pnpm vitest run --project=unit src/services/ecosystem/__tests__/bridge.test.ts

Note:
- pnpm typecheck:run currently fails on existing unrelated repo issues.