### PR TITLE
fix(dweb): disable virtual keyboard overlay by default

### DIFF
--- a/src/lib/dweb-keyboard-overlay.test.ts
+++ b/src/lib/dweb-keyboard-overlay.test.ts
@@ -17,7 +17,7 @@ describe('dweb keyboard overlay', () => {
     expect(loadPlugins).not.toHaveBeenCalled()
   })
 
-  it('applies overlay in dweb environment', async () => {
+  it('disables overlay in dweb environment', async () => {
     const setOverlay = vi.fn<(overlay: boolean) => Promise<void>>().mockResolvedValue()
     const loadPlugins = vi.fn<() => Promise<DwebPluginsModule>>().mockResolvedValue({
       virtualKeyboardPlugin: { setOverlay },
@@ -30,7 +30,7 @@ describe('dweb keyboard overlay', () => {
 
     expect(result).toBe(true)
     expect(loadPlugins).toHaveBeenCalledTimes(1)
-    expect(setOverlay).toHaveBeenCalledWith(true)
+    expect(setOverlay).toHaveBeenCalledWith(false)
   })
 
   it('returns false when virtual keyboard plugin is unavailable', async () => {

--- a/src/lib/dweb-keyboard-overlay.ts
+++ b/src/lib/dweb-keyboard-overlay.ts
@@ -19,7 +19,8 @@ async function defaultLoadPlugins(): Promise<DwebPluginsModule> {
 }
 
 /**
- * 在 DWEB 环境启用键盘 overlay，避免输入法弹出导致 document 发生 resize。
+ * 在 DWEB 环境配置键盘 overlay 行为。
+ * 当前策略：显式关闭 overlay，避免部分环境下的输入异常。
  */
 export async function applyDwebKeyboardOverlay(
   options: ApplyDwebKeyboardOverlayOptions = {},
@@ -38,7 +39,7 @@ export async function applyDwebKeyboardOverlay(
       return false
     }
 
-    await virtualKeyboardPlugin.setOverlay(true)
+    await virtualKeyboardPlugin.setOverlay(false)
     return true
   } catch (error) {
     console.warn('[dweb-keyboard-overlay] apply failed', error)


### PR DESCRIPTION
## Summary
- set dweb virtual keyboard overlay to false
- update unit test assertions accordingly

## Verification
- pnpm vitest run --project=unit src/lib/dweb-keyboard-overlay.test.ts