### PR TITLE
fix: validate crypto authorize pattern against target wallet

### DIFF
--- a/src/services/crypto-box/executor.ts
+++ b/src/services/crypto-box/executor.ts
@@ -18,6 +18,7 @@ import type {
     AsymmetricEncryptParams,
     SignParams,
 } from './types'
+import { CryptoBoxErrorCodes } from './types'
 
 // 导入加密工具
 import {
@@ -141,7 +142,10 @@ class CryptoExecutor {
             if (err instanceof Error && err.message.includes('Address mismatch')) {
                 throw err
             }
-            throw new Error(`Failed to get keypair for wallet ${walletId}: invalid patternKey or wallet not found`)
+            throw Object.assign(
+                new Error('Crypto authorization is invalid. Please re-authorize.'),
+                { code: CryptoBoxErrorCodes.INVALID_SESSION_SECRET }
+            )
         }
     }
 

--- a/src/stackflow/activities/sheets/__tests__/crypto-authorize-pattern.test.ts
+++ b/src/stackflow/activities/sheets/__tests__/crypto-authorize-pattern.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetMnemonic } = vi.hoisted(() => ({
+  mockGetMnemonic: vi.fn(),
+}))
+
+vi.mock('@/services/wallet-storage', () => ({
+  walletStorageService: {
+    getMnemonic: mockGetMnemonic,
+  },
+}))
+
+import { verifyCryptoAuthorizePattern } from '../crypto-authorize-pattern'
+
+describe('verifyCryptoAuthorizePattern', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns false when walletId is missing', async () => {
+    const result = await verifyCryptoAuthorizePattern(undefined, '0-1-2-5-8')
+    expect(result).toBe(false)
+    expect(mockGetMnemonic).not.toHaveBeenCalled()
+  })
+
+  it('validates pattern against target wallet only', async () => {
+    mockGetMnemonic.mockResolvedValueOnce('mnemonic')
+
+    const result = await verifyCryptoAuthorizePattern('wallet-target', '0-1-2-5-8')
+
+    expect(result).toBe(true)
+    expect(mockGetMnemonic).toHaveBeenCalledTimes(1)
+    expect(mockGetMnemonic).toHaveBeenCalledWith('wallet-target', '0-1-2-5-8')
+  })
+
+  it('returns false when target wallet pattern is invalid', async () => {
+    mockGetMnemonic.mockRejectedValueOnce(new Error('Failed to decrypt mnemonic'))
+
+    const result = await verifyCryptoAuthorizePattern('wallet-target', '0-1-2-5-8')
+
+    expect(result).toBe(false)
+    expect(mockGetMnemonic).toHaveBeenCalledTimes(1)
+    expect(mockGetMnemonic).toHaveBeenCalledWith('wallet-target', '0-1-2-5-8')
+  })
+})

--- a/src/stackflow/activities/sheets/crypto-authorize-pattern.ts
+++ b/src/stackflow/activities/sheets/crypto-authorize-pattern.ts
@@ -1,0 +1,11 @@
+import { walletStorageService } from '@/services/wallet-storage'
+
+export async function verifyCryptoAuthorizePattern(walletId: string | undefined, patternKey: string): Promise<boolean> {
+  if (!walletId) return false
+  try {
+    await walletStorageService.getMnemonic(walletId, patternKey)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary\n- validate crypto authorization pattern only against the selected target wallet\n- avoid leaking internal walletId in crypto execute invalid-authorization errors\n- add unit tests for wallet-targeted pattern verification\n\n## Validation\n- pnpm vitest run --project=unit src/stackflow/activities/sheets/__tests__/crypto-authorize-pattern.test.ts src/stackflow/activities/sheets/__tests__/miniapp-auth.test.ts\n- pnpm vitest run --project=unit src/services/crypto-box/__tests__/token-store.test.ts\n