### PR TITLE
fix: use bio_selectAccount for biobridge external account

### DIFF
--- a/miniapps/biobridge/src/App.test.tsx
+++ b/miniapps/biobridge/src/App.test.tsx
@@ -178,4 +178,41 @@ describe('Forge App', () => {
       )
     })
   })
+
+  it('should use bio_selectAccount for external chain account', async () => {
+    mockBio.request.mockImplementation(({ method, params }: { method: string; params?: Array<{ chain?: string }> }) => {
+      if (method === 'bio_closeSplashScreen') return Promise.resolve(null)
+      if (method === 'bio_selectAccount') {
+        const chain = params?.[0]?.chain
+        if (chain === 'ethereum') {
+          return Promise.resolve({ address: '0xexternal-bio', chain: 'ethereum' })
+        }
+        return Promise.resolve({ address: 'bfmeta123', chain: 'bfmeta' })
+      }
+      return Promise.resolve(null)
+    })
+
+    render(<App />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('connect-button')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTestId('connect-button'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/支付/)).toBeInTheDocument()
+      expect(screen.getByText('0xexternal-bio')).toBeInTheDocument()
+    })
+
+    expect(mockBio.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'bio_selectAccount',
+        params: [{ chain: 'ethereum' }],
+      })
+    )
+    expect(mockEthereum.request).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'eth_requestAccounts' })
+    )
+  })
 })

--- a/miniapps/biobridge/src/App.tsx
+++ b/miniapps/biobridge/src/App.tsx
@@ -7,7 +7,6 @@ import { useState, useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { BioAccount } from '@biochain/bio-sdk';
 import { normalizeChainId } from '@biochain/bio-sdk';
-import { getChainType, getEvmChainIdFromApi } from '@/lib/chain';
 import { parseAmount } from '@/lib/fee';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
@@ -170,53 +169,10 @@ export default function App() {
     setError(null);
     try {
       const externalChain = activeOption.externalChain;
-      const chainType = getChainType(externalChain);
-
-      let extAcc: BioAccount;
-
-      if (chainType === 'evm') {
-        if (!window.ethereum) {
-          throw new Error('Ethereum provider not available');
-        }
-        const evmChainId = getEvmChainIdFromApi(externalChain);
-        if (evmChainId) {
-          await window.ethereum.request({
-            method: 'wallet_switchEthereumChain',
-            params: [{ chainId: evmChainId }],
-          });
-        }
-        const accounts = await window.ethereum.request<string[]>({
-          method: 'eth_requestAccounts',
-        });
-        if (!accounts || accounts.length === 0) {
-          throw new Error('No accounts returned');
-        }
-        extAcc = {
-          address: accounts[0],
-          chain: normalizeChainId(externalChain),
-          publicKey: '',
-        };
-      } else if (chainType === 'tron') {
-        if (!window.tronLink) {
-          throw new Error('TronLink provider not available');
-        }
-        const result = await window.tronLink.request<{ code: number; message: string; data: { base58: string } }>({
-          method: 'tron_requestAccounts',
-        });
-        if (!result || result.code !== 200) {
-          throw new Error('TRON connection failed');
-        }
-        extAcc = {
-          address: result.data.base58,
-          chain: 'tron',
-          publicKey: '',
-        };
-      } else {
-        extAcc = await window.bio.request<BioAccount>({
-          method: 'bio_selectAccount',
-          params: [{ chain: normalizeChainId(externalChain) }],
-        });
-      }
+      const extAcc = await window.bio.request<BioAccount>({
+        method: 'bio_selectAccount',
+        params: [{ chain: normalizeChainId(externalChain) }],
+      });
       setExternalAccount(extAcc);
 
       const intAcc = await window.bio.request<BioAccount>({


### PR DESCRIPTION
## Summary
- route biobridge external account selection through `bio_selectAccount` for all external chains
- remove direct `window.ethereum` / `window.tronLink` account sourcing from biobridge connect step
- add regression test to ensure ETH flow uses `bio_selectAccount` and not `eth_requestAccounts`

## Why
User reports showed BSC forge flow could pick a non-expected address. This change enforces KeyApp account selection as the single source of truth for forge sender address in miniapp runtime.

## Validation
- Added unit regression test in `miniapps/biobridge/src/App.test.tsx`
- Local test run was blocked by missing Storybook/Vitest workspace deps in current environment; CI to verify fully.
