### PR TITLE
test(biobridge): stabilize reconnect assertion timing

### DIFF
--- a/miniapps/biobridge/src/App.test.tsx
+++ b/miniapps/biobridge/src/App.test.tsx
@@ -251,8 +251,6 @@ describe('Forge App', () => {
 
     fireEvent.click(screen.getByTestId('reconnect-button'))
 
-    await waitFor(() => {
-      expect(screen.getByTestId('connect-button')).toBeInTheDocument()
-    })
+    await screen.findByTestId('connect-button', undefined, { timeout: 5000 })
   })
 })


### PR DESCRIPTION
## Summary
- stabilize reconnect test by waiting for connect-button with a longer async query
- avoid flaky release/CI failures during biobridge unit tests

## Validation
- pnpm --filter @biochain/miniapp-biobridge exec vitest run --project=unit src/App.test.tsx (x2)