### PR TITLE
fix(teleport): correct ratio direction

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -421,7 +421,7 @@ jobs:
               echo "No release assets found"
               exit 1
             fi
-            if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            if gh release view "$TAG_NAME" -R "$REPO" >/dev/null 2>&1; then
               release_json=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG_NAME")
               upload_files=()
               for file in "${release_files[@]}"; do
@@ -436,10 +436,11 @@ jobs:
               if [ "${#upload_files[@]}" -eq 0 ]; then
                 echo "All release assets already exist, skip upload"
               else
-                gh release upload "$TAG_NAME" "${upload_files[@]}"
+                gh release upload "$TAG_NAME" -R "$REPO" "${upload_files[@]}"
               fi
             else
               gh release create "$TAG_NAME" \
+                -R "$REPO" \
                 --title "$RELEASE_TITLE" \
                 --notes "$RELEASE_NOTES" \
                 ${{ steps.channel.outputs.channel == 'beta' && '--prerelease' || '' }} \
@@ -448,6 +449,7 @@ jobs:
             fi
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           TAG_NAME: ${{ steps.channel.outputs.channel == 'stable' && format('v{0}', steps.version.outputs.version) || 'beta' }}
           RELEASE_TITLE: ${{ steps.channel.outputs.channel == 'stable' && format('BFM Pay v{0}', steps.version.outputs.version) || 'BFM Pay Beta' }}
           RELEASE_NOTES: |
@@ -951,7 +953,7 @@ jobs:
               echo "No release assets found"
               exit 1
             fi
-            if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            if gh release view "$TAG_NAME" -R "$REPO" >/dev/null 2>&1; then
               release_json=$(gh api "repos/${{ github.repository }}/releases/tags/$TAG_NAME")
               upload_files=()
               for file in "${release_files[@]}"; do
@@ -966,10 +968,11 @@ jobs:
               if [ "${#upload_files[@]}" -eq 0 ]; then
                 echo "All release assets already exist, skip upload"
               else
-                gh release upload "$TAG_NAME" "${upload_files[@]}"
+                gh release upload "$TAG_NAME" -R "$REPO" "${upload_files[@]}"
               fi
             else
               gh release create "$TAG_NAME" \
+                -R "$REPO" \
                 --title "$RELEASE_TITLE" \
                 --notes "$RELEASE_NOTES" \
                 ${{ needs.build-standard.outputs.channel == 'beta' && '--prerelease' || '' }} \
@@ -978,6 +981,7 @@ jobs:
             fi
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           TAG_NAME: ${{ needs.build-standard.outputs.channel == 'stable' && format('v{0}', needs.build-standard.outputs.version) || 'beta' }}
           RELEASE_TITLE: ${{ needs.build-standard.outputs.channel == 'stable' && format('BFM Pay v{0}', needs.build-standard.outputs.version) || 'BFM Pay Beta' }}
           RELEASE_NOTES: |

--- a/miniapps/teleport/src/App.test.tsx
+++ b/miniapps/teleport/src/App.test.tsx
@@ -472,8 +472,12 @@ describe('Teleport App', () => {
     fireEvent.click(screen.getByTestId('target-button'))
 
     await waitFor(() => {
-      expect(screen.getByText('1 BFT = 0.0416 BFM')).toBeInTheDocument()
-      expect(screen.getByText(/416 BFM/)).toBeInTheDocument()
+      expect(screen.getByText('1 BFT = 24.03846154 BFM')).toBeInTheDocument()
+      expect(screen.getByText('1 BFM = 0.0416 BFT')).toBeInTheDocument()
+      expect(
+        screen.getAllByText((_, node) => node?.textContent?.includes('240384.61538462 BFM') ?? false)
+          .length,
+      ).toBeGreaterThan(0)
     })
   })
 

--- a/miniapps/teleport/src/App.tsx
+++ b/miniapps/teleport/src/App.tsx
@@ -265,6 +265,16 @@ const formatRatioRate = (
   if (!ratio) return '0';
   const numerator = Number(ratio.numerator);
   const denominator = Number(ratio.denominator);
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || numerator === 0) return '0';
+  return (denominator / numerator).toFixed(8).replace(/\.?0+$/, '');
+};
+
+const formatInverseRatioRate = (
+  ratio: { numerator: number | string; denominator: number | string } | null | undefined,
+): string => {
+  if (!ratio) return '0';
+  const numerator = Number(ratio.numerator);
+  const denominator = Number(ratio.denominator);
   if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator === 0) return '0';
   return (numerator / denominator).toFixed(8).replace(/\.?0+$/, '');
 };
@@ -602,7 +612,7 @@ export default function App() {
     if (!selectedAsset || !amount) return '0';
     const amountNum = Number(amount);
     if (!Number.isFinite(amountNum)) return '0';
-    const ratioNum = Number(selectedAsset.ratio.numerator) / Number(selectedAsset.ratio.denominator);
+    const ratioNum = Number(selectedAsset.ratio.denominator) / Number(selectedAsset.ratio.numerator);
     if (!Number.isFinite(ratioNum)) return '0';
     return (amountNum * ratioNum).toFixed(8).replace(/\.?0+$/, '');
   }, [selectedAsset, amount]);
@@ -746,6 +756,7 @@ export default function App() {
                   ) : (
                     sortedAvailableAssets.map((asset, i) => {
                       const rate = formatRatioRate(asset.ratio);
+                      const inverseRate = formatInverseRatioRate(asset.ratio);
                       const routeLabel = `${asset.chain}/${asset.symbol} ${t('common.arrow')} ${asset.targetChain}/${asset.targetAsset}`;
                       return (
                         <motion.div
@@ -770,8 +781,17 @@ export default function App() {
                                 <AssetAvatar symbol={asset.symbol} chain={asset.chain} />
                                 <div className="min-w-0 flex-1">
                                   <CardTitle className="text-base break-words">{routeLabel}</CardTitle>
-                                  <CardDescription>
-                                    {t('asset.ratio', { from: asset.symbol, rate, to: asset.targetAsset })}
+                                  <CardDescription className="space-y-0.5">
+                                    <div>
+                                      {t('asset.ratio', { from: asset.symbol, rate, to: asset.targetAsset })}
+                                    </div>
+                                    <div className="text-muted-foreground/70">
+                                      {t('asset.ratio', {
+                                        from: asset.targetAsset,
+                                        rate: inverseRate,
+                                        to: asset.symbol,
+                                      })}
+                                    </div>
                                   </CardDescription>
                                 </div>
                               </div>
@@ -996,12 +1016,20 @@ export default function App() {
                     <Separator />
                     <div className="flex justify-between">
                       <span className="text-muted-foreground">{t('confirm.ratio')}</span>
-                      <span>
+                      <span className="text-right">
                         {t('asset.ratio', {
                           from: selectedAsset?.symbol ?? '',
                           rate: formatRatioRate(selectedAsset?.ratio),
                           to: selectedAsset?.targetAsset ?? '',
                         })}
+                        <br />
+                        <span className="text-muted-foreground/70">
+                          {t('asset.ratio', {
+                            from: selectedAsset?.targetAsset ?? '',
+                            rate: formatInverseRatioRate(selectedAsset?.ratio),
+                            to: selectedAsset?.symbol ?? '',
+                          })}
+                        </span>
                       </span>
                     </div>
                     <Separator />


### PR DESCRIPTION
## Summary
- fix teleport ratio direction to match backend semantics (denominator / numerator)
- update expected receive calculation and ratio copy display (both directions)
- update teleport unit test for corrected semantics
- harden release workflow gh release calls with explicit -R repo binding

## Validation
- pnpm --filter @biochain/miniapp-teleport typecheck:run
- pnpm --filter @biochain/miniapp-teleport test:run -- -t "should display ratio semantics clearly on confirm step"