### PR TITLE
fix(teleport): restore ratio semantics to match backend config

### DIFF
--- a/miniapps/teleport/src/App.test.tsx
+++ b/miniapps/teleport/src/App.test.tsx
@@ -472,10 +472,10 @@ describe('Teleport App', () => {
     fireEvent.click(screen.getByTestId('target-button'))
 
     await waitFor(() => {
-      expect(screen.getByText('1 BFT = 24.03846154 BFM')).toBeInTheDocument()
-      expect(screen.getByText('1 BFM = 0.0416 BFT')).toBeInTheDocument()
+      expect(screen.getByText('1 BFT = 0.0416 BFM')).toBeInTheDocument()
+      expect(screen.getByText('1 BFM = 24.03846154 BFT')).toBeInTheDocument()
       expect(
-        screen.getAllByText((_, node) => node?.textContent?.includes('240384.61538462 BFM') ?? false)
+        screen.getAllByText((_, node) => node?.textContent?.includes('416 BFM') ?? false)
           .length,
       ).toBeGreaterThan(0)
     })

--- a/miniapps/teleport/src/App.tsx
+++ b/miniapps/teleport/src/App.tsx
@@ -265,8 +265,8 @@ const formatRatioRate = (
   if (!ratio) return '0';
   const numerator = Number(ratio.numerator);
   const denominator = Number(ratio.denominator);
-  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || numerator === 0) return '0';
-  return (denominator / numerator).toFixed(8).replace(/\.?0+$/, '');
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator === 0) return '0';
+  return (numerator / denominator).toFixed(8).replace(/\.?0+$/, '');
 };
 
 const formatInverseRatioRate = (
@@ -275,8 +275,8 @@ const formatInverseRatioRate = (
   if (!ratio) return '0';
   const numerator = Number(ratio.numerator);
   const denominator = Number(ratio.denominator);
-  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || denominator === 0) return '0';
-  return (numerator / denominator).toFixed(8).replace(/\.?0+$/, '');
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator) || numerator === 0) return '0';
+  return (denominator / numerator).toFixed(8).replace(/\.?0+$/, '');
 };
 
 export default function App() {
@@ -612,7 +612,7 @@ export default function App() {
     if (!selectedAsset || !amount) return '0';
     const amountNum = Number(amount);
     if (!Number.isFinite(amountNum)) return '0';
-    const ratioNum = Number(selectedAsset.ratio.denominator) / Number(selectedAsset.ratio.numerator);
+    const ratioNum = Number(selectedAsset.ratio.numerator) / Number(selectedAsset.ratio.denominator);
     if (!Number.isFinite(ratioNum)) return '0';
     return (amountNum * ratioNum).toFixed(8).replace(/\.?0+$/, '');
   }, [selectedAsset, amount]);


### PR DESCRIPTION
## Summary
- restore teleport ratio direction back to `numerator/denominator`
- restore inverse display to `denominator/numerator`
- align expected receive calculation with restored ratio semantics
- update confirm-step test assertions accordingly

## Notes
- this reverts the previous frontend ratio flip after backend confirmed config was incorrect, not frontend math