### PR TITLE
fix: enforce miniapp two-step secret flow for signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 更新日志
 
+## [1.0.20] - 2026-03-01
+
+fix miniapp 二次密码签名流程并补全 signSignature required 识别
+
+<!-- last-commit: pending -->
+
 ## [1.0.19] - 2026-03-01
 
 修复传送门比例语义回退，与后端配置一致

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@biochain/keyapp",
   "private": true,
-  "version": "1.0.19",
+  "version": "1.0.20",
   "type": "module",
   "packageManager": "pnpm@10.28.0",
   "scripts": {

--- a/src/stackflow/activities/sheets/MiniappConfirmJobs.regression.test.tsx
+++ b/src/stackflow/activities/sheets/MiniappConfirmJobs.regression.test.tsx
@@ -65,9 +65,7 @@ vi.mock('@/components/wallet/address-display', () => ({
 }));
 
 vi.mock('@/components/common/amount-display', () => ({
-  AmountDisplay: ({ value, symbol }: { value: string; symbol: string }) => (
-    <span>{`${value}-${symbol}`}</span>
-  ),
+  AmountDisplay: ({ value, symbol }: { value: string; symbol: string }) => <span>{`${value}-${symbol}`}</span>,
 }));
 
 vi.mock('@/components/wallet/chain-icon', () => ({
@@ -89,11 +87,7 @@ vi.mock('@/components/security/pattern-lock', () => ({
     footerText?: string;
   }) => (
     <div>
-      <button
-        type="button"
-        data-testid="pattern-lock"
-        onClick={() => onComplete?.([1, 2, 3, 4])}
-      >
+      <button type="button" data-testid="pattern-lock" onClick={() => onComplete?.([1, 2, 3, 4])}>
         pattern
       </button>
       <span data-testid="pattern-lock-hint">{hintText ?? ''}</span>
@@ -135,7 +129,8 @@ vi.mock('@/components/security/password-input', () => ({
 
 vi.mock('./miniapp-auth', () => ({
   isMiniappWalletLockError: (error: unknown) => error instanceof Error && error.message.includes('wallet lock'),
-  isMiniappTwoStepSecretError: (error: unknown) => error instanceof Error && error.message.includes('pay password'),
+  isMiniappTwoStepSecretError: (error: unknown) =>
+    error instanceof Error && /(pay password|sign\s*signature(?:\s+is)?\s+required|001-11003)/i.test(error.message),
   resolveMiniappTwoStepSecretRequired: vi.fn(async () => false),
 }));
 
@@ -144,6 +139,7 @@ import { MiniappSignTransactionJob } from './MiniappSignTransactionJob';
 import { signUnsignedTransaction } from '@/services/ecosystem/handlers';
 import { getChainProvider } from '@/services/chain-adapter/providers';
 import { superjson } from '@biochain/chain-effect';
+import { resolveMiniappTwoStepSecretRequired } from './miniapp-auth';
 
 describe('miniapp confirm jobs regressions', () => {
   beforeEach(() => {
@@ -152,22 +148,26 @@ describe('miniapp confirm jobs regressions', () => {
     hoisted.currentParams = {};
 
     vi.mocked(getChainProvider).mockReset();
-    vi.mocked(getChainProvider).mockImplementation(() => ({
-      supportsFullTransaction: true,
-      buildTransaction: vi.fn(async (intent: unknown) => ({
-        chainId: 'bfmetav2',
-        intentType: 'transfer',
-        data: intent,
-      })),
-      signTransaction: vi.fn(),
-      broadcastTransaction: vi.fn(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 50));
-        return 'tx-hash';
-      }),
-    } as unknown as ReturnType<typeof getChainProvider>));
+    vi.mocked(getChainProvider).mockImplementation(
+      () =>
+        ({
+          supportsFullTransaction: true,
+          buildTransaction: vi.fn(async (intent: unknown) => ({
+            chainId: 'bfmetav2',
+            intentType: 'transfer',
+            data: intent,
+          })),
+          signTransaction: vi.fn(),
+          broadcastTransaction: vi.fn(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            return 'tx-hash';
+          }),
+        }) as unknown as ReturnType<typeof getChainProvider>,
+    );
 
     vi.mocked(signUnsignedTransaction).mockReset();
     vi.mocked(signUnsignedTransaction).mockResolvedValue({ chainId: 'bfmetav2', data: { tx: '1' }, signature: 'sig' });
+    vi.mocked(resolveMiniappTwoStepSecretRequired).mockResolvedValue(false);
 
     walletStore.setState(() => ({
       wallets: [
@@ -270,6 +270,48 @@ describe('miniapp confirm jobs regressions', () => {
       expect(screen.getByTestId('pattern-lock-hint').textContent?.length).toBeGreaterThan(0);
     });
     expect(screen.getByTestId('pattern-lock-footer').textContent).toContain('sign service timeout');
+  });
+
+  it('requires two-step secret before miniapp signing when account has second public key', async () => {
+    vi.mocked(resolveMiniappTwoStepSecretRequired).mockResolvedValueOnce(true);
+
+    render(
+      <MiniappSignTransactionJob
+        params={{
+          appName: 'Org App',
+          appIcon: '',
+          from: 'b_sender_1',
+          chain: 'BFMetaV2',
+          unsignedTx: superjson.stringify({
+            chainId: 'bfmetav2',
+            intentType: 'transfer',
+            data: { tx: 'unsigned' },
+          }),
+        }}
+      />,
+    );
+
+    const signButton = screen.getByTestId('miniapp-sign-review-confirm');
+    await waitFor(() => {
+      expect(signButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(signButton);
+    fireEvent.click(screen.getByTestId('pattern-lock'));
+
+    expect(await screen.findByTestId('password-input')).toBeInTheDocument();
+    expect(vi.mocked(signUnsignedTransaction)).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByTestId('password-input'), { target: { value: '123456' } });
+    fireEvent.click(screen.getByTestId('miniapp-sign-two-step-secret-confirm'));
+
+    await waitFor(() => {
+      expect(vi.mocked(signUnsignedTransaction)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paySecret: '123456',
+        }),
+      );
+    });
   });
 
   it('does not pass raw amount directly to display layer', () => {
@@ -392,6 +434,46 @@ describe('miniapp confirm jobs regressions', () => {
     expect(intent.amount.toRawString()).toBe('1000000000');
   });
 
+  it('requires two-step secret before miniapp transfer signing when account has second public key', async () => {
+    vi.mocked(resolveMiniappTwoStepSecretRequired).mockResolvedValueOnce(true);
+
+    render(
+      <MiniappTransferConfirmJob
+        params={{
+          appName: 'Org App',
+          appIcon: '',
+          from: 'b_sender_1',
+          to: 'b_receiver_1',
+          amount: '1000',
+          chain: 'BFMetaV2',
+          asset: 'BFM',
+        }}
+      />,
+    );
+
+    const confirmButton = screen.getByTestId('miniapp-transfer-review-confirm');
+    await waitFor(() => {
+      expect(confirmButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(confirmButton);
+    fireEvent.click(screen.getByTestId('pattern-lock'));
+
+    expect(await screen.findByTestId('password-input')).toBeInTheDocument();
+    expect(vi.mocked(signUnsignedTransaction)).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByTestId('password-input'), { target: { value: '654321' } });
+    fireEvent.click(screen.getByTestId('miniapp-transfer-two-step-secret-confirm'));
+
+    await waitFor(() => {
+      expect(vi.mocked(signUnsignedTransaction)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paySecret: '654321',
+        }),
+      );
+    });
+  });
+
   it('passes remark into transaction intent and keeps it in emitted transaction', async () => {
     const buildTransaction = vi.fn(async (intent: unknown) => ({
       chainId: 'bfmetav2',
@@ -412,18 +494,20 @@ describe('miniapp confirm jobs regressions', () => {
       signature: 'sig',
     }));
 
-    const eventPromise = new Promise<CustomEvent<{ confirmed?: boolean; transaction?: Record<string, unknown> }>>((resolve) => {
-      const handleEvent = (event: Event) => {
-        const customEvent = event as CustomEvent<{ confirmed?: boolean; transaction?: Record<string, unknown> }>;
-        if (customEvent.detail?.confirmed !== true) {
-          return;
-        }
-        window.removeEventListener('miniapp-transfer-confirm', handleEvent);
-        resolve(customEvent);
-      };
+    const eventPromise = new Promise<CustomEvent<{ confirmed?: boolean; transaction?: Record<string, unknown> }>>(
+      (resolve) => {
+        const handleEvent = (event: Event) => {
+          const customEvent = event as CustomEvent<{ confirmed?: boolean; transaction?: Record<string, unknown> }>;
+          if (customEvent.detail?.confirmed !== true) {
+            return;
+          }
+          window.removeEventListener('miniapp-transfer-confirm', handleEvent);
+          resolve(customEvent);
+        };
 
-      window.addEventListener('miniapp-transfer-confirm', handleEvent);
-    });
+        window.addEventListener('miniapp-transfer-confirm', handleEvent);
+      },
+    );
 
     render(
       <MiniappTransferConfirmJob
@@ -564,7 +648,6 @@ describe('miniapp confirm jobs regressions', () => {
     expect(buildTransaction).not.toHaveBeenCalled();
     expect(broadcastTransaction).not.toHaveBeenCalled();
   });
-
 
   it('ignores duplicated unlock submission while transfer is in-flight', async () => {
     vi.mocked(signUnsignedTransaction).mockImplementation(async () => {
@@ -751,24 +834,27 @@ describe('miniapp confirm jobs regressions', () => {
   });
 
   it('uses toast and exits broadcasting state when background broadcast fails', async () => {
-    vi.mocked(getChainProvider).mockImplementation(() => ({
-      supportsFullTransaction: true,
-      buildTransaction: vi.fn(async (intent: unknown) => ({
-        chainId: 'bfmetav2',
-        intentType: 'transfer',
-        data: intent,
-      })),
-      signTransaction: vi.fn(),
-      broadcastTransaction: vi.fn(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 50));
-        throw new ChainServiceError(
-          ChainErrorCodes.TX_BROADCAST_FAILED,
-          'Failed to broadcast transaction',
-          undefined,
-          new Error('Request timeout'),
-        );
-      }),
-    } as unknown as ReturnType<typeof getChainProvider>));
+    vi.mocked(getChainProvider).mockImplementation(
+      () =>
+        ({
+          supportsFullTransaction: true,
+          buildTransaction: vi.fn(async (intent: unknown) => ({
+            chainId: 'bfmetav2',
+            intentType: 'transfer',
+            data: intent,
+          })),
+          signTransaction: vi.fn(),
+          broadcastTransaction: vi.fn(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            throw new ChainServiceError(
+              ChainErrorCodes.TX_BROADCAST_FAILED,
+              'Failed to broadcast transaction',
+              undefined,
+              new Error('Request timeout'),
+            );
+          }),
+        }) as unknown as ReturnType<typeof getChainProvider>,
+    );
 
     vi.mocked(signUnsignedTransaction).mockResolvedValue({ chainId: 'bfmetav2', data: { tx: '1' }, signature: 'sig' });
 
@@ -819,22 +905,23 @@ describe('miniapp confirm jobs regressions', () => {
     expect(screen.queryByTestId('miniapp-transfer-error')).not.toBeInTheDocument();
   });
 
-
   it('emits transfer result with the same requestId', async () => {
     const requestId = 'transfer-test-request-id';
 
-    const eventPromise = new Promise<CustomEvent<{ requestId?: string; confirmed?: boolean; txHash?: string }>>((resolve) => {
-      const handleEvent = (event: Event) => {
-        const customEvent = event as CustomEvent<{ requestId?: string; confirmed?: boolean; txHash?: string }>;
-        if (customEvent.detail?.requestId !== requestId) {
-          return;
-        }
-        window.removeEventListener('miniapp-transfer-confirm', handleEvent);
-        resolve(customEvent);
-      };
+    const eventPromise = new Promise<CustomEvent<{ requestId?: string; confirmed?: boolean; txHash?: string }>>(
+      (resolve) => {
+        const handleEvent = (event: Event) => {
+          const customEvent = event as CustomEvent<{ requestId?: string; confirmed?: boolean; txHash?: string }>;
+          if (customEvent.detail?.requestId !== requestId) {
+            return;
+          }
+          window.removeEventListener('miniapp-transfer-confirm', handleEvent);
+          resolve(customEvent);
+        };
 
-      window.addEventListener('miniapp-transfer-confirm', handleEvent);
-    });
+        window.addEventListener('miniapp-transfer-confirm', handleEvent);
+      },
+    );
 
     render(
       <MiniappTransferConfirmJob
@@ -883,27 +970,32 @@ describe('miniapp confirm jobs regressions', () => {
       };
     });
 
-    vi.mocked(getChainProvider).mockImplementation(() => ({
-      supportsFullTransaction: true,
-      buildTransaction: vi.fn(async (intent: unknown) => ({
-        chainId: 'bfmetav2',
-        intentType: 'transfer',
-        data: intent,
-      })),
-      signTransaction: vi.fn(),
-      broadcastTransaction: vi.fn(async (signedTx: { data: unknown }) => {
-        const payload = signedTx.data as { signature?: string };
-        return 'tx-hash-' + (payload.signature ?? 'unknown');
-      }),
-    } as unknown as ReturnType<typeof getChainProvider>));
+    vi.mocked(getChainProvider).mockImplementation(
+      () =>
+        ({
+          supportsFullTransaction: true,
+          buildTransaction: vi.fn(async (intent: unknown) => ({
+            chainId: 'bfmetav2',
+            intentType: 'transfer',
+            data: intent,
+          })),
+          signTransaction: vi.fn(),
+          broadcastTransaction: vi.fn(async (signedTx: { data: unknown }) => {
+            const payload = signedTx.data as { signature?: string };
+            return 'tx-hash-' + (payload.signature ?? 'unknown');
+          }),
+        }) as unknown as ReturnType<typeof getChainProvider>,
+    );
 
     const runTransfer = async (requestId: string) => {
-      const eventPromise = new Promise<CustomEvent<{
-        requestId?: string;
-        confirmed?: boolean;
-        txHash?: string;
-        transaction?: Record<string, unknown>;
-      }>>((resolve) => {
+      const eventPromise = new Promise<
+        CustomEvent<{
+          requestId?: string;
+          confirmed?: boolean;
+          txHash?: string;
+          transaction?: Record<string, unknown>;
+        }>
+      >((resolve) => {
         const handleEvent = (event: Event) => {
           const customEvent = event as CustomEvent<{
             requestId?: string;

--- a/src/stackflow/activities/sheets/MiniappSignTransactionJob.tsx
+++ b/src/stackflow/activities/sheets/MiniappSignTransactionJob.tsx
@@ -205,6 +205,17 @@ function MiniappSignTransactionJobContent() {
         return;
       }
 
+      if (requiresTwoStepSecret) {
+        setPattern(nodes);
+        setPatternError(false);
+        setTwoStepSecret('');
+        setTwoStepSecretError(false);
+        setErrorMessage(null);
+        setErrorDetail(null);
+        setStep('two_step_secret');
+        return;
+      }
+
       const password = patternToString(nodes);
       setIsSubmitting(true);
       setPatternError(false);
@@ -240,7 +251,7 @@ function MiniappSignTransactionJobContent() {
         setIsSubmitting(false);
       }
     },
-    [isSubmitting, unsignedTx, walletId, performSign, t],
+    [isSubmitting, unsignedTx, walletId, requiresTwoStepSecret, performSign, t],
   );
 
   const handleTwoStepSecretSubmit = useCallback(async () => {
@@ -489,6 +500,7 @@ function MiniappSignTransactionJobContent() {
               </button>
               <button
                 onClick={handleTwoStepSecretConfirm}
+                data-testid="miniapp-sign-two-step-secret-confirm"
                 disabled={isSubmitting || twoStepSecret.trim().length === 0}
                 className={cn(
                   'flex-1 rounded-xl py-3 font-medium transition-colors',

--- a/src/stackflow/activities/sheets/MiniappTransferConfirmJob.tsx
+++ b/src/stackflow/activities/sheets/MiniappTransferConfirmJob.tsx
@@ -124,12 +124,7 @@ function parseAmountLike(value: unknown): Amount | null {
   const decimalsValue = value.decimals;
   const symbolValue = value.symbol;
 
-  const raw =
-    typeof rawValue === 'string'
-      ? rawValue
-      : typeof rawValue === 'number'
-        ? String(rawValue)
-        : null;
+  const raw = typeof rawValue === 'string' ? rawValue : typeof rawValue === 'number' ? String(rawValue) : null;
   const decimals = typeof decimalsValue === 'number' ? decimalsValue : null;
   const symbol = typeof symbolValue === 'string' ? symbolValue : undefined;
 
@@ -152,8 +147,22 @@ function MiniappTransferConfirmJobContent() {
   const { pop } = useFlow();
   const toast = useToast();
   const params = useActivityParams<MiniappTransferConfirmJobParams>();
-  const { requestId, mode, appName, appIcon, from, to, amount, chain, asset, remark, unsignedTx: unsignedTxJson } = params;
-  const fallbackRequestIdRef = useRef(requestId ?? `legacy-transfer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  const {
+    requestId,
+    mode,
+    appName,
+    appIcon,
+    from,
+    to,
+    amount,
+    chain,
+    asset,
+    remark,
+    unsignedTx: unsignedTxJson,
+  } = params;
+  const fallbackRequestIdRef = useRef(
+    requestId ?? `legacy-transfer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+  );
   const effectiveRequestId = fallbackRequestIdRef.current;
   const isSignMode = mode === 'sign';
 
@@ -230,7 +239,10 @@ function MiniappTransferConfirmJobContent() {
     return Amount.tryFromFormatted(feeText, feeDecimals, feeSymbol) ?? null;
   }, [feeDecimals, feeInput, feeSymbol, isSignMode]);
 
-  const displayAmount = useMemo(() => parsedAmount?.toFormatted({ trimTrailingZeros: false }) ?? amount, [parsedAmount, amount]);
+  const displayAmount = useMemo(
+    () => parsedAmount?.toFormatted({ trimTrailingZeros: false }) ?? amount,
+    [parsedAmount, amount],
+  );
   const amountInvalidMessage = useMemo(
     () => (parsedAmount ? null : t('transaction:broadcast.invalidParams')),
     [parsedAmount, t],
@@ -427,59 +439,64 @@ function MiniappTransferConfirmJobContent() {
     };
   }, [resolvedChainId, from]);
 
+  const emitTransferResult = useCallback(
+    (detail: MiniappTransferResultDetail) => {
+      if (didDispatchResultRef.current) {
+        return;
+      }
 
-  const emitTransferResult = useCallback((detail: MiniappTransferResultDetail) => {
-    if (didDispatchResultRef.current) {
-      return;
-    }
+      didDispatchResultRef.current = true;
+      if (typeof window === 'undefined') {
+        return;
+      }
 
-    didDispatchResultRef.current = true;
-    if (typeof window === 'undefined') {
-      return;
-    }
+      const payload: MiniappTransferResultDetail = {
+        requestId: effectiveRequestId,
+        ...detail,
+      };
 
-    const payload: MiniappTransferResultDetail = {
-      requestId: effectiveRequestId,
-      ...detail,
-    };
+      logTransferSheet('sheet.emit', {
+        confirmed: payload.confirmed,
+        hasTxHash: Boolean(payload.txHash),
+        hasTransaction: Boolean(payload.transaction),
+        hasSignedTx: Boolean(payload.signedTx),
+        txId: payload.txId,
+      });
 
-    logTransferSheet('sheet.emit', {
-      confirmed: payload.confirmed,
-      hasTxHash: Boolean(payload.txHash),
-      hasTransaction: Boolean(payload.transaction),
-      hasSignedTx: Boolean(payload.signedTx),
-      txId: payload.txId,
-    });
+      window.dispatchEvent(
+        new CustomEvent('miniapp-transfer-confirm', {
+          detail: payload,
+        }),
+      );
+    },
+    [effectiveRequestId, logTransferSheet],
+  );
 
-    window.dispatchEvent(
-      new CustomEvent('miniapp-transfer-confirm', {
-        detail: payload,
-      }),
-    );
-  }, [effectiveRequestId, logTransferSheet]);
+  const emitSheetClosed = useCallback(
+    (reason: MiniappTransferSheetClosedDetail['reason']) => {
+      if (didDispatchCloseRef.current) {
+        return;
+      }
 
-  const emitSheetClosed = useCallback((reason: MiniappTransferSheetClosedDetail['reason']) => {
-    if (didDispatchCloseRef.current) {
-      return;
-    }
+      didDispatchCloseRef.current = true;
+      if (typeof window === 'undefined') {
+        return;
+      }
 
-    didDispatchCloseRef.current = true;
-    if (typeof window === 'undefined') {
-      return;
-    }
+      const payload: MiniappTransferSheetClosedDetail = {
+        requestId: effectiveRequestId,
+        reason,
+      };
 
-    const payload: MiniappTransferSheetClosedDetail = {
-      requestId: effectiveRequestId,
-      reason,
-    };
-
-    logTransferSheet('sheet.closed', payload);
-    window.dispatchEvent(
-      new CustomEvent('miniapp-transfer-sheet-closed', {
-        detail: payload,
-      }),
-    );
-  }, [effectiveRequestId, logTransferSheet]);
+      logTransferSheet('sheet.closed', payload);
+      window.dispatchEvent(
+        new CustomEvent('miniapp-transfer-sheet-closed', {
+          detail: payload,
+        }),
+      );
+    },
+    [effectiveRequestId, logTransferSheet],
+  );
 
   useEffect(() => {
     if (!isSuccess || successCountdown === null) {
@@ -585,9 +602,7 @@ function MiniappTransferConfirmJobContent() {
           ...(paySecret ? { paySecret } : {}),
         });
 
-        const transaction = isRecord(signedTx.data)
-          ? cloneTransactionRecord(signedTx.data)
-          : { data: signedTx.data };
+        const transaction = isRecord(signedTx.data) ? cloneTransactionRecord(signedTx.data) : { data: signedTx.data };
 
         return { signedTx, transaction };
       }
@@ -626,9 +641,9 @@ function MiniappTransferConfirmJobContent() {
 
       const signedTxForBroadcast = isRecord(signedTx.data)
         ? {
-          ...signedTx,
-          data: cloneTransactionRecord(signedTx.data),
-        }
+            ...signedTx,
+            data: cloneTransactionRecord(signedTx.data),
+          }
         : signedTx;
 
       if (isMountedRef.current) {
@@ -648,7 +663,11 @@ function MiniappTransferConfirmJobContent() {
 
   const handleTransferFailure = useCallback(
     (error: unknown, inputStep: TransferInputStep) => {
-      const { message: mappedError, detail: mappedErrorDetail } = resolveMiniappTransferErrorFeedback(t, error, resolvedChainId);
+      const { message: mappedError, detail: mappedErrorDetail } = resolveMiniappTransferErrorFeedback(
+        t,
+        error,
+        resolvedChainId,
+      );
       if (isBackgroundBroadcastRef.current) {
         if (isMountedRef.current) {
           setStep(inputStep);
@@ -793,7 +812,18 @@ function MiniappTransferConfirmJobContent() {
         }
       }
     },
-    [emitSheetClosed, emitTransferResult, handleTransferFailure, isSignMode, logTransferSheet, performTransfer, pop, t, toast, transferShortTitle],
+    [
+      emitSheetClosed,
+      emitTransferResult,
+      handleTransferFailure,
+      isSignMode,
+      logTransferSheet,
+      performTransfer,
+      pop,
+      t,
+      toast,
+      transferShortTitle,
+    ],
   );
 
   const handlePatternComplete = useCallback(
@@ -802,10 +832,21 @@ function MiniappTransferConfirmJobContent() {
         return;
       }
 
+      if (requiresTwoStepSecret) {
+        setPattern(nodes);
+        setPatternError(false);
+        setTwoStepSecret('');
+        setTwoStepSecretError(false);
+        setErrorMessage(null);
+        setErrorDetail(null);
+        setStep('two_step_secret');
+        return;
+      }
+
       const password = patternToString(nodes);
       await runTransfer(password, 'wallet_lock');
     },
-    [isBusy, walletId, runTransfer],
+    [isBusy, walletId, requiresTwoStepSecret, runTransfer],
   );
 
   const handleTwoStepSecretSubmit = useCallback(async () => {
@@ -850,7 +891,17 @@ function MiniappTransferConfirmJobContent() {
     emitTransferResult({ confirmed: false });
     emitSheetClosed('cancel');
     pop();
-  }, [emitSheetClosed, emitTransferResult, handleSuccessClose, isBroadcasting, isBuilding, isSuccess, logTransferSheet, moveToBackgroundBroadcast, pop]);
+  }, [
+    emitSheetClosed,
+    emitTransferResult,
+    handleSuccessClose,
+    isBroadcasting,
+    isBuilding,
+    isSuccess,
+    logTransferSheet,
+    moveToBackgroundBroadcast,
+    pop,
+  ]);
 
   const walletLockServiceMessage = !patternError && errorMessage ? errorMessage : null;
   const walletLockErrorDetail = !patternError ? errorDetail : null;
@@ -931,9 +982,7 @@ function MiniappTransferConfirmJobContent() {
               )}
 
               {amountInvalidMessage && (
-                <div className="bg-destructive/10 text-destructive rounded-xl p-3 text-sm">
-                  {amountInvalidMessage}
-                </div>
+                <div className="bg-destructive/10 text-destructive rounded-xl p-3 text-sm">{amountInvalidMessage}</div>
               )}
 
               <div className="bg-muted/50 flex items-center justify-between rounded-xl p-3">
@@ -968,7 +1017,7 @@ function MiniappTransferConfirmJobContent() {
               {remarkEntries.length > 0 && (
                 <div data-testid="miniapp-transfer-remark" className="bg-muted/50 space-y-2 rounded-xl p-3">
                   <span className="text-muted-foreground text-xs">{t('memo')}</span>
-                  <div className="max-h-36 space-y-1 overflow-y-auto pr-1 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-[color-mix(in_srgb,currentColor,transparent)]">
+                  <div className="scrollbar-thin scrollbar-track-transparent scrollbar-thumb-[color-mix(in_srgb,currentColor,transparent)] max-h-36 space-y-1 overflow-y-auto pr-1">
                     {remarkEntries.map((entry, index) => (
                       <div
                         key={entry.key}
@@ -978,7 +1027,7 @@ function MiniappTransferConfirmJobContent() {
                         )}
                       >
                         <span className="text-muted-foreground min-w-0 break-all">{entry.key}</span>
-                        <span className="min-w-0 break-all text-right">{entry.value}</span>
+                        <span className="min-w-0 text-right break-all">{entry.value}</span>
                       </div>
                     ))}
                   </div>
@@ -1002,7 +1051,13 @@ function MiniappTransferConfirmJobContent() {
               <button
                 data-testid="miniapp-transfer-review-confirm"
                 onClick={handleEnterWalletLockStep}
-                disabled={isBusy || !walletId || isResolvingTwoStepSecret || !parsedAmount || (isSignMode && (isFeeEstimating || !parsedFeeAmount))}
+                disabled={
+                  isBusy ||
+                  !walletId ||
+                  isResolvingTwoStepSecret ||
+                  !parsedAmount ||
+                  (isSignMode && (isFeeEstimating || !parsedFeeAmount))
+                }
                 className={cn(
                   'flex-1 rounded-xl py-3 font-medium transition-colors',
                   'bg-primary text-primary-foreground hover:bg-primary/90',
@@ -1110,6 +1165,7 @@ function MiniappTransferConfirmJobContent() {
               </button>
               <button
                 onClick={handleTwoStepSecretConfirm}
+                data-testid="miniapp-transfer-two-step-secret-confirm"
                 disabled={isBusy || twoStepSecret.trim().length === 0}
                 className={cn(
                   'flex-1 rounded-xl py-3 font-medium transition-colors',
@@ -1158,7 +1214,7 @@ function MiniappTransferConfirmJobContent() {
             {remarkEntries.length > 0 && (
               <div data-testid="miniapp-transfer-remark" className="bg-muted/50 space-y-2 rounded-xl p-3">
                 <span className="text-muted-foreground text-xs">{t('memo')}</span>
-                <div className="max-h-36 space-y-1 overflow-y-auto pr-1 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-[color-mix(in_srgb,currentColor,transparent)]">
+                <div className="scrollbar-thin scrollbar-track-transparent scrollbar-thumb-[color-mix(in_srgb,currentColor,transparent)] max-h-36 space-y-1 overflow-y-auto pr-1">
                   {remarkEntries.map((entry, index) => (
                     <div
                       key={entry.key}
@@ -1168,7 +1224,7 @@ function MiniappTransferConfirmJobContent() {
                       )}
                     >
                       <span className="text-muted-foreground min-w-0 break-all">{entry.key}</span>
-                      <span className="min-w-0 break-all text-right">{entry.value}</span>
+                      <span className="min-w-0 text-right break-all">{entry.value}</span>
                     </div>
                   ))}
                 </div>

--- a/src/stackflow/activities/sheets/__tests__/miniapp-auth.test.ts
+++ b/src/stackflow/activities/sheets/__tests__/miniapp-auth.test.ts
@@ -21,5 +21,20 @@ describe('miniapp-auth', () => {
   it('detects two-step secret errors from plain error message', () => {
     expect(isMiniappTwoStepSecretError(new Error('security password invalid'))).toBe(true);
   });
-});
 
+  it('detects two-step secret required errors from signSignature validation message', () => {
+    expect(
+      isMiniappTwoStepSecretError(
+        new Error('Transaction signSignature is required, signature xxx senderId yyy type BFM-BFMETA-ASST-02'),
+      ),
+    ).toBe(true);
+  });
+
+  it('detects two-step secret required errors from chain code 001-11003 message', () => {
+    const error = new ChainServiceError(
+      ChainErrorCodes.SIGNATURE_FAILED,
+      '001-11003: Transaction signSignature is required',
+    );
+    expect(isMiniappTwoStepSecretError(error)).toBe(true);
+  });
+});

--- a/src/stackflow/activities/sheets/miniapp-auth.ts
+++ b/src/stackflow/activities/sheets/miniapp-auth.ts
@@ -2,7 +2,8 @@ import { getChainProvider } from '@/services/chain-adapter/providers';
 import { ChainErrorCodes, ChainServiceError } from '@/services/chain-adapter/types';
 import { WalletStorageError, WalletStorageErrorCode } from '@/services/wallet-storage/types';
 
-const PAY_SECRET_ERROR_PATTERN = /pay password|pay secret|second secret|security password/i;
+const TWO_STEP_SECRET_ERROR_PATTERN =
+  /pay password|pay secret|second secret|security password|sign\s*signature(?:\s+is)?\s+required|001-11003/i;
 
 export function isMiniappWalletLockError(error: unknown): boolean {
   if (error instanceof WalletStorageError) {
@@ -20,14 +21,13 @@ export function isMiniappWalletLockError(error: unknown): boolean {
 
 export function isMiniappTwoStepSecretError(error: unknown): boolean {
   if (error instanceof ChainServiceError) {
-    if (error.code === ChainErrorCodes.SIGNATURE_FAILED && PAY_SECRET_ERROR_PATTERN.test(error.message)) {
+    if (error.code === ChainErrorCodes.SIGNATURE_FAILED && TWO_STEP_SECRET_ERROR_PATTERN.test(error.message)) {
       return true;
     }
-
   }
 
   if (error instanceof Error) {
-    return PAY_SECRET_ERROR_PATTERN.test(error.message);
+    return TWO_STEP_SECRET_ERROR_PATTERN.test(error.message);
   }
 
   return false;
@@ -46,4 +46,3 @@ export async function resolveMiniappTwoStepSecretRequired(chainId: string, addre
     return false;
   }
 }
-


### PR DESCRIPTION
Closes #499

## Summary
- enforce two-step secret flow in miniapp sign sheet: when account requires second secret, pattern step now routes to two-step input before signing
- enforce the same rule in miniapp transfer confirm sheet to keep behavior consistent with Send flow
- expand two-step secret error recognition to include `signSignature is required` / `001-11003`
- add regression tests for two-step gating and error detection
- bump version to `1.0.20` and update changelog

## Validation
- `pnpm vitest run src/stackflow/activities/sheets/__tests__/miniapp-auth.test.ts src/stackflow/activities/sheets/MiniappConfirmJobs.regression.test.tsx`
  - 26 passed
